### PR TITLE
Added Jump Buffering

### DIFF
--- a/Assets/OpenKCC/Prefab/Player.prefab
+++ b/Assets/OpenKCC/Prefab/Player.prefab
@@ -157,11 +157,6 @@ MonoBehaviour:
   gravity: {x: 0, y: -18, z: 0}
   walkingSpeed: 7.5
   sprintSpeed: 10
-  jumpVelocity: 6.5
-  maxJumpAngle: 75
-  jumpAngleWeightFactor: 0
-  jumpCooldown: 0.5
-  coyoteTime: 0.25
   maxBounces: 5
   pushDecay: 0.25
   anglePower: 1
@@ -170,6 +165,12 @@ MonoBehaviour:
   stepUpDepth: 0.1
   verticalSnapUp: 0.3
   snapBufferTime: 0.05
+  jumpVelocity: 6.5
+  maxJumpAngle: 75
+  jumpAngleWeightFactor: 0
+  jumpCooldown: 0.5
+  coyoteTime: 0.25
+  jumpBufferTime: 0.05
   earlyStopProneThreshold: 0.4
   thresholdAngularVelocity: 15
   thresholdVelocity: 0.1
@@ -345,6 +346,7 @@ MonoBehaviour:
   movementDistance: 5
   fillAlpha: 0.5
   outlineAlpha: 1
+  useProjectedMovement: 1
   bounceColors:
   - {r: 0, g: 0.21883087, b: 0.8584906, a: 1}
   - {r: 0.006830946, g: 0.0037379938, b: 0.7924528, a: 1}

--- a/Assets/OpenKCC/Scenes/SampleScene.unity
+++ b/Assets/OpenKCC/Scenes/SampleScene.unity
@@ -66648,10 +66648,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Player
       objectReference: {fileID: 0}
-    - target: {fileID: 1928389238801210305, guid: 0ba88b23b077d354ba94e3d1c4f22966, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 1928389238801210310, guid: 0ba88b23b077d354ba94e3d1c4f22966, type: 3}
       propertyPath: m_RootOrder
       value: 4
@@ -66695,10 +66691,6 @@ PrefabInstance:
     - target: {fileID: 1928389238801210310, guid: 0ba88b23b077d354ba94e3d1c4f22966, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1928389238801210311, guid: 0ba88b23b077d354ba94e3d1c4f22966, type: 3}
-      propertyPath: jumpBufferTime
-      value: 0.05
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0ba88b23b077d354ba94e3d1c4f22966, type: 3}

--- a/Assets/OpenKCC/Scenes/SampleScene.unity
+++ b/Assets/OpenKCC/Scenes/SampleScene.unity
@@ -66696,6 +66696,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1928389238801210311, guid: 0ba88b23b077d354ba94e3d1c4f22966, type: 3}
+      propertyPath: jumpBufferTime
+      value: 0.05
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0ba88b23b077d354ba94e3d1c4f22966, type: 3}
 --- !u!4 &2576008796230917357 stripped


### PR DESCRIPTION
# Description

Added basic Jump buffering to the KCC and grouped KCC jump inputs together for the UI.

Jump buffering allows for the player to hit the "jump" action but allow the player to jump while still in the air by "buffering" an input so they jump as soon as they hit the ground. This allows for the player to press the "jump" button right before hitting the ground but still get a jump action. That way, even if the player hits jump a little bit before they touch the ground and let go of the button, they still get to jump. The default jump buffer time is 0.05 seconds (or 1/20th of a second). This should be about 1-3 frames depending on how fast the player's computer is. Fixed update updates at a rate of 60 times per second so it should allow for 3 frames of error if the player's computer is able to render at 60 fps. It will always provide a minimum of one frame of error if the fps is lower.

As shown in the settings image below, all the jump actions were grouped together under a single heading.

![image](https://user-images.githubusercontent.com/3240136/152091393-f09619c4-06d6-4adf-9c47-2b4b96a067b2.png)

# How Has This Been Tested?

Tested this change locally in the editor to ensure it works as expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
