### PR TITLE
Added Debug Draw Ground Angle

### DIFF
--- a/Assets/OpenKCC/Prefab/Player.prefab
+++ b/Assets/OpenKCC/Prefab/Player.prefab
@@ -51,6 +51,7 @@ GameObject:
   - component: {fileID: 1849976359}
   - component: {fileID: 1497970301217932205}
   - component: {fileID: 1928389240043740980}
+  - component: {fileID: 907866501}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -400,6 +401,27 @@ MonoBehaviour:
   floatingColor: {r: 1, g: 0.8469602, b: 0, a: 1}
   fillAlpha: 0.5
   outlineAlpha: 1
+--- !u!114 &907866501
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1928389238801210305}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fdd1547483fc3cd439e2ebcd64f7e2fc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  groundCheckDistance: 1
+  groundedDistance: 1
+  groundedColor: {r: 0, g: 0, b: 1, a: 1}
+  slidingColor: {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
+  fillAlpha: 0.1
+  debugAngleLength: 0.5
+  thresholdAngle: 60
+  pointRadius: 0.01
+  useGroundPosition: 0
 --- !u!1001 &1928389239579011581
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/OpenKCC/Scripts/Demo/DrawKCCGroundedAngle.cs
+++ b/Assets/OpenKCC/Scripts/Demo/DrawKCCGroundedAngle.cs
@@ -1,0 +1,157 @@
+﻿// Copyright (C) 2022 Nicholas Maltbie
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using nickmaltbie.OpenKCC.Character;
+using nickmaltbie.OpenKCC.Utils;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+using UnityEngine;
+
+namespace nickmaltbie.OpenKCC.Demo
+{
+    /// <summary>
+    /// Draw angle the kcc makes between the ground and their player as a debug gizmo.
+    /// </summary>
+    [RequireComponent(typeof(KinematicCharacterController))]
+    public class DrawKCCGroundedAngle : MonoBehaviour
+    {
+        /// <summary>
+        /// Kinematic character controller reference.
+        /// </summary>
+        private KinematicCharacterController kcc;
+
+        /// <summary>
+        /// Collider cast for checking movement and collision of the character controller.
+        /// </summary>
+        private IColliderCast colliderCast;
+
+        /// <summary>
+        /// How far should the downward cast be made.
+        /// </summary>
+        public float groundCheckDistance = 1.0f;
+
+        /// <summary>
+        /// How far is considered grounded.
+        /// </summary>
+        public float groundedDistance = 0.0f;
+
+        /// <summary>
+        /// Color of player when standing on the ground.
+        /// </summary>
+        [SerializeField]
+        [Tooltip("Color of player when standing on the ground.")]
+        public Color groundedColor = Color.blue;
+
+        /// <summary>
+        /// Color of of player when over the sliding threshold.
+        /// </summary>
+        [SerializeField]
+        [Tooltip("Color of of player when over the sliding threshold.")]
+        public Color slidingColor = Color.yellow;
+
+        /// <summary>
+        /// Alpha value for drawing the angle arc.
+        /// </summary>
+        [SerializeField]
+        [Tooltip("Alpha value for drawing the angle arc.")]
+        [Range(0, 1)]
+        public float fillAlpha = 0.5f;
+
+        /// <summary>
+        /// Length of arc for drawing character angle.
+        /// </summary>
+        [SerializeField]
+        [Tooltip("Length of arc for drawing character angle.")]
+        [Range(0, 2)]
+        public float debugAngleLength = 0.5f;
+
+        /// <summary>
+        /// Treshold angle for when player is considered sliding.
+        /// </summary>
+        [SerializeField]
+        [Tooltip("Treshold angle for when player is considered sliding.")]
+        [Range(0, 90.0f)]
+        public float thresholdAngle = 60f;
+
+        /// <summary>
+        /// Radius of grounded draw point.
+        /// </summary>
+        [SerializeField]
+        [Tooltip("Radius of grounded draw point.")]
+        public float pointRadius = 0.01f;
+
+        /// <summary>
+        /// Should the ground position be used to draw the angle or should it be drawn from the origin of the kcc's
+        /// feet. 
+        /// </summary>
+        [SerializeField]
+        [Tooltip("Location to draw angle, at ground position (true) or feet (false).")]
+        public bool useGroundPosition = true;
+
+        public void Start()
+        {
+            kcc = GetComponent<KinematicCharacterController>();
+            colliderCast = GetComponent<IColliderCast>();
+        }
+
+        public void OnDrawGizmos()
+        {
+            if (kcc == null)
+            {
+                kcc = GetComponent<KinematicCharacterController>();
+            }
+
+            if (colliderCast == null)
+            {
+                colliderCast = GetComponent<IColliderCast>();
+            }
+
+            bool hitGround = colliderCast.CastSelf(
+                transform.position,
+                transform.rotation,
+                Vector3.down,
+                groundCheckDistance,
+                out RaycastHit hit);
+
+            if (hitGround)
+            {
+                bool isGrounded = hitGround && hit.distance <= groundedDistance;
+
+                Vector3 source = useGroundPosition ? hit.point : colliderCast.GetBottom(
+                    transform.position, transform.rotation);
+
+                float angle = Vector3.Angle(kcc.Up, hit.normal);
+                bool sliding = angle >= thresholdAngle;
+
+                Color selectedColor = sliding ? slidingColor : groundedColor;
+                Gizmos.DrawWireSphere(hit.point, pointRadius);
+                Gizmos.color = selectedColor;
+                Gizmos.DrawRay(source, Vector3.up * debugAngleLength);
+                Gizmos.DrawRay(source, hit.normal * debugAngleLength);
+
+#if UNITY_EDITOR
+                Handles.color = selectedColor;
+                Handles.DrawWireArc(source, Vector3.Cross(hit.normal, kcc.Up), kcc.Up, -angle, debugAngleLength);
+                Handles.color = new Color(selectedColor.r, selectedColor.g, selectedColor.b, fillAlpha);
+                Handles.DrawSolidArc(source, Vector3.Cross(hit.normal, kcc.Up), kcc.Up, -angle, debugAngleLength);
+#endif
+            }
+        }
+    }
+}

--- a/Assets/OpenKCC/Scripts/Demo/DrawKCCGroundedAngle.cs.meta
+++ b/Assets/OpenKCC/Scripts/Demo/DrawKCCGroundedAngle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fdd1547483fc3cd439e2ebcd64f7e2fc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Description

Added some debug code to draw angle between player and ground. This will draw an arc between the player and the ground to show what kind of an angle the player is making between the ground and vertical. This shows how step of an angle the player is climbing/walking at. If the angle is too great, it will turn yellow showing that the player is now sliding down a surface. This angle has a set of various configurations such as color, size, and position.

![image](https://user-images.githubusercontent.com/3240136/152104259-3577afce-1791-4136-8a82-e483fd99946b.png)

# How Has This Been Tested?

Tested locally in the editor to ensure it has the expected look when drawing the player.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
