### PR TITLE
Slope Jump Glitch

### DIFF
--- a/Assets/OpenKCC/Scripts/Character/KinematicCharacterController.cs
+++ b/Assets/OpenKCC/Scripts/Character/KinematicCharacterController.cs
@@ -280,7 +280,7 @@ namespace nickmaltbie.OpenKCC.Character
         /// <summary>
         /// Has the player jumped while sliding?
         /// </summary>
-        private bool jumpedWhileSliding = false;
+        private bool notSlidingSinceJump = true;
 
         /// <summary>
         /// Current player velocity
@@ -428,7 +428,7 @@ namespace nickmaltbie.OpenKCC.Character
         /// Can the player jump right now.
         /// </summary>
         public bool CanJump => elapsedFalling >= 0 && (!FallingAngle(maxJumpAngle) || elapsedFalling <= coyoteTime) &&
-            AttemptingJump && elapsedSinceJump >= jumpCooldown && (!Falling || !jumpedWhileSliding);
+            AttemptingJump && elapsedSinceJump >= jumpCooldown && (!Falling || !notSlidingSinceJump);
 
         /// <summary>
         /// Can a player snap down this frame, a player is only allowed to snap down
@@ -681,7 +681,7 @@ namespace nickmaltbie.OpenKCC.Character
                 {
                     velocity = Vector3.zero;
                     elapsedFalling = 0.0f;
-                    jumpedWhileSliding = false;
+                    notSlidingSinceJump = true;
                 }
                 else if (Falling)
                 {
@@ -833,7 +833,7 @@ namespace nickmaltbie.OpenKCC.Character
                 // If the player successfully jumped, reset elapsed since jump and jump buffer
                 elapsedSinceJump = 0.0f;
                 jumpBufferRemaining = 0;
-                jumpedWhileSliding = true;
+                notSlidingSinceJump = false;
 
                 return true;
             }

--- a/Assets/OpenKCC/Scripts/Character/KinematicCharacterController.cs
+++ b/Assets/OpenKCC/Scripts/Character/KinematicCharacterController.cs
@@ -276,7 +276,7 @@ namespace nickmaltbie.OpenKCC.Character
         /// /// How long has the player been falling.
         /// </summary>
         private float elapsedFalling;
-        
+
         /// <summary>
         /// Has the player jumped while sliding?
         /// </summary>
@@ -428,7 +428,7 @@ namespace nickmaltbie.OpenKCC.Character
         /// Can the player jump right now.
         /// </summary>
         public bool CanJump => elapsedFalling >= 0 && (!FallingAngle(maxJumpAngle) || elapsedFalling <= coyoteTime) &&
-            AttemptingJump && elapsedSinceJump >= jumpCooldown && (!Falling || !notSlidingSinceJump);
+            AttemptingJump && elapsedSinceJump >= jumpCooldown && (!Falling || notSlidingSinceJump);
 
         /// <summary>
         /// Can a player snap down this frame, a player is only allowed to snap down

--- a/Assets/OpenKCC/Scripts/Character/KinematicCharacterController.cs
+++ b/Assets/OpenKCC/Scripts/Character/KinematicCharacterController.cs
@@ -276,6 +276,11 @@ namespace nickmaltbie.OpenKCC.Character
         /// /// How long has the player been falling.
         /// </summary>
         private float elapsedFalling;
+        
+        /// <summary>
+        /// Has the player jumped while sliding?
+        /// </summary>
+        private bool jumpedWhileSliding = false;
 
         /// <summary>
         /// Current player velocity
@@ -423,7 +428,7 @@ namespace nickmaltbie.OpenKCC.Character
         /// Can the player jump right now.
         /// </summary>
         public bool CanJump => elapsedFalling >= 0 && (!FallingAngle(maxJumpAngle) || elapsedFalling <= coyoteTime) &&
-            AttemptingJump && elapsedSinceJump >= jumpCooldown;
+            AttemptingJump && elapsedSinceJump >= jumpCooldown && (!Falling || !jumpedWhileSliding);
 
         /// <summary>
         /// Can a player snap down this frame, a player is only allowed to snap down
@@ -676,6 +681,7 @@ namespace nickmaltbie.OpenKCC.Character
                 {
                     velocity = Vector3.zero;
                     elapsedFalling = 0.0f;
+                    jumpedWhileSliding = false;
                 }
                 else if (Falling)
                 {
@@ -827,6 +833,7 @@ namespace nickmaltbie.OpenKCC.Character
                 // If the player successfully jumped, reset elapsed since jump and jump buffer
                 elapsedSinceJump = 0.0f;
                 jumpBufferRemaining = 0;
+                jumpedWhileSliding = true;
 
                 return true;
             }

--- a/Assets/OpenKCC/Scripts/Demo/SimplifiedKCCWithJump.cs
+++ b/Assets/OpenKCC/Scripts/Demo/SimplifiedKCCWithJump.cs
@@ -197,6 +197,11 @@ namespace nickmaltbie.OpenKCC.Demo
         private float elapsedFalling = 0f;
 
         /// <summary>
+        /// Has the player jumped while sliding?
+        /// </summary>
+        private bool jumpedWhileSliding = false;
+
+        /// <summary>
         /// Velocity at which player is moving.
         /// </summary>
         private Vector3 velocity;
@@ -266,6 +271,7 @@ namespace nickmaltbie.OpenKCC.Demo
             {
                 velocity = Vector3.zero;
                 elapsedFalling = 0;
+                jumpedWhileSliding = false;
             }
 
             // If the player is attemtping to jump and can jump allow for player jump
@@ -277,10 +283,11 @@ namespace nickmaltbie.OpenKCC.Demo
             bool attemptingJump = jumpInputElapsed <= jumpBufferTime;
 
             // Player can jump if they are (1) on the ground, (2) within the ground jump angle,
-            //  (3) and has not jumped within the jump cooldown time period.
+            //  (3) has not jumped within the jump cooldown time period, and (4) has only jumped once while sliding
             bool canJump = (onGround || elapsedFalling <= coyoteTime) &&
                 groundAngle <= maxJumpAngle &&
-                timeSinceLastJump >= jumpCooldown;
+                timeSinceLastJump >= jumpCooldown &&
+                (!falling || !jumpedWhileSliding);
 
             // Have player jump if they can jump and are attempting to jump
             if (canJump && attemptingJump)
@@ -288,6 +295,9 @@ namespace nickmaltbie.OpenKCC.Demo
                 velocity = Vector3.Lerp(Vector3.up, groundHit.normal, jumpAngleWeightFactor) * jumpVelocity;
                 timeSinceLastJump = 0.0f;
                 jumpInputElapsed = Mathf.Infinity;
+
+                // Mark if the player is jumping while they are sliding
+                jumpedWhileSliding = true;
             }
             else
             {

--- a/Assets/OpenKCC/Scripts/Demo/SimplifiedKCCWithJump.cs
+++ b/Assets/OpenKCC/Scripts/Demo/SimplifiedKCCWithJump.cs
@@ -199,7 +199,7 @@ namespace nickmaltbie.OpenKCC.Demo
         /// <summary>
         /// Has the player jumped while sliding?
         /// </summary>
-        private bool jumpedWhileSliding = false;
+        private bool notSlidingSinceJump = true;
 
         /// <summary>
         /// Velocity at which player is moving.
@@ -271,7 +271,7 @@ namespace nickmaltbie.OpenKCC.Demo
             {
                 velocity = Vector3.zero;
                 elapsedFalling = 0;
-                jumpedWhileSliding = false;
+                notSlidingSinceJump = true;
             }
 
             // If the player is attemtping to jump and can jump allow for player jump
@@ -287,7 +287,7 @@ namespace nickmaltbie.OpenKCC.Demo
             bool canJump = (onGround || elapsedFalling <= coyoteTime) &&
                 groundAngle <= maxJumpAngle &&
                 timeSinceLastJump >= jumpCooldown &&
-                (!falling || !jumpedWhileSliding);
+                (!falling || notSlidingSinceJump);
 
             // Have player jump if they can jump and are attempting to jump
             if (canJump && attemptingJump)
@@ -297,7 +297,7 @@ namespace nickmaltbie.OpenKCC.Demo
                 jumpInputElapsed = Mathf.Infinity;
 
                 // Mark if the player is jumping while they are sliding
-                jumpedWhileSliding = true;
+                notSlidingSinceJump = false;
             }
             else
             {


### PR DESCRIPTION
# Description

Fixed bug in code that allowed for a player to jump up a slanted slope even if it was too steep for them to walk up. This allowed a player to jump up a slope even if it was too steep to walk up.

This could have been fixed by increasing the cooldown but the setting of not being able to jump until they land on a solid surface after jumping is a good policy. If the player walks off a surface (not jumps off) and lands on a steep slope they will be able to jump off the steep slope. All the other effects such as coyote time and input buffering still work as expected.

# How Has This Been Tested?

Tested in the editor to ensure it works as expected and that the player is not able to jump up extremely steep slopes as long as they want.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
