### PR TITLE
Bugfix KCC Angle Jitter

### DIFF
--- a/Assets/OpenKCC/Scripts/Utils/KCCUtils.cs
+++ b/Assets/OpenKCC/Scripts/Utils/KCCUtils.cs
@@ -317,9 +317,11 @@ namespace nickmaltbie.OpenKCC.Utils
 
             float fraction = hit.distance / distance;
             // Set the fraction of remaining movement (minus some small value)
-            position += remainingMomentum * Mathf.Max(0, fraction - Epsilon);
+            Vector3 deltaBounce = remainingMomentum * fraction;
+            deltaBounce = deltaBounce.normalized * Mathf.Max(0, deltaBounce.magnitude - Epsilon * 2);
+            position += deltaBounce;
             // Decrease remaining momentum by fraction of movement remaining
-            remainingMomentum *= (1 - Mathf.Max(0, fraction - Epsilon));
+            remainingMomentum *= (1 - Mathf.Max(0, deltaBounce.magnitude / distance));
 
             if (config.CanSnapUp && AttemptSnapUp(hit, remainingMomentum, ref position, rotation, config))
             {
@@ -394,7 +396,7 @@ namespace nickmaltbie.OpenKCC.Utils
                 {
                     didSnapUp = true;
                 }
-                else if (Vector3.Dot(bounce.Movement, movement) <= 0)
+                else if (Vector3.Dot(bounce.Movement, movement) < 0)
                 {
                     break;
                 }

--- a/Assets/OpenKCC/Scripts/Utils/KCCUtils.cs
+++ b/Assets/OpenKCC/Scripts/Utils/KCCUtils.cs
@@ -318,7 +318,7 @@ namespace nickmaltbie.OpenKCC.Utils
             float fraction = hit.distance / distance;
             // Set the fraction of remaining movement (minus some small value)
             Vector3 deltaBounce = remainingMomentum * fraction;
-            deltaBounce = deltaBounce.normalized * Mathf.Max(0, deltaBounce.magnitude - Epsilon * 2);
+            deltaBounce = deltaBounce.normalized * Mathf.Max(0, deltaBounce.magnitude - Epsilon);
             position += deltaBounce;
             // Decrease remaining momentum by fraction of movement remaining
             remainingMomentum *= (1 - Mathf.Max(0, deltaBounce.magnitude / distance));

--- a/Assets/OpenKCC/Scripts/Utils/KCCUtils.cs
+++ b/Assets/OpenKCC/Scripts/Utils/KCCUtils.cs
@@ -159,7 +159,7 @@ namespace nickmaltbie.OpenKCC.Utils
                     out IRaycastHit snapHit);
 
             // If they can move without instantly hitting something, then snap them up
-            if (snapHit.distance >= Epsilon && (!didSnapHit || snapHit.distance > config.StepUpDepth))
+            if (!didSnapHit || (snapHit.distance >= Epsilon && snapHit.distance > config.StepUpDepth))
             {
                 position = snapPos;
                 return true;

--- a/Assets/OpenKCC/Scripts/Utils/KCCUtils.cs
+++ b/Assets/OpenKCC/Scripts/Utils/KCCUtils.cs
@@ -317,11 +317,9 @@ namespace nickmaltbie.OpenKCC.Utils
 
             float fraction = hit.distance / distance;
             // Set the fraction of remaining movement (minus some small value)
-            position += remainingMomentum * (fraction);
-            // Push slightly along normal to stop from getting caught in walls
-            position += hit.normal * Epsilon * 2;
+            position += remainingMomentum * Mathf.Max(0, fraction - Epsilon);
             // Decrease remaining momentum by fraction of movement remaining
-            remainingMomentum *= (1 - fraction);
+            remainingMomentum *= (1 - Mathf.Max(0, fraction - Epsilon));
 
             if (config.CanSnapUp && AttemptSnapUp(hit, remainingMomentum, ref position, rotation, config))
             {
@@ -396,6 +394,10 @@ namespace nickmaltbie.OpenKCC.Utils
                 {
                     didSnapUp = true;
                 }
+                else if (Vector3.Dot(bounce.Movement, movement) <= 0)
+                {
+                    break;
+                }
 
                 yield return bounce;
 
@@ -412,7 +414,6 @@ namespace nickmaltbie.OpenKCC.Utils
             }
 
             // We're done, player was moved as part of loop
-
             yield return new KCCBounce
             {
                 initialPosition = position,

--- a/Assets/Tests/EditMode/KCCUtilsTests.cs
+++ b/Assets/Tests/EditMode/KCCUtilsTests.cs
@@ -78,15 +78,16 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode
         {
             // Have the object hit some collider and not move at all
             Vector3 initialPosition = Vector3.zero;
-            Vector3 movement = Vector3.forward;
+            Vector3 movement = Vector3.forward * 10;
 
             // Have collider return hitting something... but it shouldn't be called due to no movement
-            SetupColliderCast(true, SetupRaycastHitMock(distance: KCCUtils.Epsilon));
+            SetupColliderCast(true, SetupRaycastHitMock(distance: 0.1f, normal: (Vector3.right + Vector3.back).normalized));
 
             // Simulate bounces
             var bounces = GetBounces(initialPosition, movement, maxBounces: maxBounces, anglePower: 0.0f).ToList();
 
             // Should hit max bounces
+            Debug.Log(string.Join("\n", bounces));
             Assert.IsTrue(bounces.Count == maxBounces + 2, $"Expected to find {maxBounces + 2} bounce but instead found {bounces.Count}");
             Enumerable.Range(0, maxBounces + 1).ToList().ForEach(idx => KCCValidation.ValidateKCCBounce(bounces[idx], KCCUtils.MovementAction.Bounce));
             KCCValidation.ValidateKCCBounce(bounces[maxBounces + 1], KCCUtils.MovementAction.Stop);
@@ -252,7 +253,10 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode
             SetupColliderCast(new[]
             {
                 // First hit should be simulating hitting a a pushable object
-                (true, SetupRaycastHitMock(collider: null, distance: KCCUtils.Epsilon)),
+                (true, SetupRaycastHitMock(
+                    collider: null,
+                    distance: 0.1f,
+                    normal: (Vector3.back + Vector3.left).normalized)),
                 // Next hit should not collide with anything as we are above the step
                 (false, SetupRaycastHitMock()),
             });
@@ -335,7 +339,8 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode
         /// <param name="collider">Collider to return from the mock.</param>
         /// <param name="point">Point of collision for the mock.</param>
         /// <param name="distance">Distance from source from the mock.</param>
-        /// <param name="normal">Normal vector for the collision from the mock..</param>
+        /// <param name="normal">Normal vector for the collision from the mock.</param>
+        /// <param name="fraction">Fraction of movement.</param>
         /// <returns>Mock raycast hit object with the specified properties.</returns>
         public IRaycastHit SetupRaycastHitMock(Collider collider = null, Vector3 point = default, Vector3 normal = default, float distance = 0.0f)
         {

--- a/Assets/Tests/EditMode/KCCUtilsTests.cs
+++ b/Assets/Tests/EditMode/KCCUtilsTests.cs
@@ -257,20 +257,16 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode
             {
                 // First hit should be simulating hitting an object and sliding to the left
                 (true, SetupRaycastHitMock(
-                    distance: distance / 10,
-                    normal: (Vector3.back + Vector3.left).normalized)),
-                // Next hit should simulate hitting another wall
-                (true, SetupRaycastHitMock(
-                    distance: distance / 10,
-                    normal: (Vector3.back).normalized)),
+                    distance: distance / 5,
+                    normal: (Vector3.back * 2 + Vector3.left).normalized)),
                 // Next hit should simulate hitting another wall and sliding back
                 (true, SetupRaycastHitMock(
-                    distance: distance / 10,
-                    normal: (Vector3.back + Vector3.right).normalized)),
+                    distance: distance / 5,
+                    normal: (Vector3.back * 2 + Vector3.right).normalized)),
             });
 
             // Simulate bounces
-            var bounces = GetBounces(Vector3.zero, Vector3.forward * distance, anglePower: 0, canSnapUp: false).ToList();
+            var bounces = GetBounces(Vector3.zero, Vector3.forward * distance, anglePower: 1, canSnapUp: false).ToList();
 
             Debug.Log(string.Join("\n", bounces));
 

--- a/Assets/Tests/EditMode/KCCUtilsTests.cs
+++ b/Assets/Tests/EditMode/KCCUtilsTests.cs
@@ -280,7 +280,7 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode
             ValidateKCCBounce(bounces[0], KCCUtils.MovementAction.Bounce);
             ValidateKCCBounce(bounces[1], KCCUtils.MovementAction.Bounce);
             ValidateKCCBounce(bounces[2], KCCUtils.MovementAction.Stop);
-            foreach (var bounce in bounces.AsEnumerable().Reverse().Skip(1))
+            foreach (KCCBounce bounce in bounces.AsEnumerable().Reverse().Skip(1))
             {
                 Assert.IsTrue(
                     Vector3.Dot(bounce.Movement, Vector3.forward) >= 0,
@@ -344,8 +344,9 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode
             Assert.IsTrue(initialMomentum == null || bounce.initialMomentum == initialMomentum, $"Expected {nameof(bounce.initialMomentum)} to be {initialMomentum} but instead found {bounce.initialMomentum}");
         }
 
-        delegate void RaycastHitCallback(Vector3 pos, Quaternion rot, Vector3 dir, float dist, out IRaycastHit hit);
-        delegate void RaycastHitReturns(out IRaycastHit hit);
+        private delegate void RaycastHitCallback(Vector3 pos, Quaternion rot, Vector3 dir, float dist, out IRaycastHit hit);
+
+        private delegate void RaycastHitReturns(out IRaycastHit hit);
 
         /// <summary>
         /// Setup the collider cast for a given set of hits in a specific order.

--- a/Assets/Tests/EditMode/KCCUtilsTests.cs
+++ b/Assets/Tests/EditMode/KCCUtilsTests.cs
@@ -172,12 +172,12 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode
         /// Validate the snap up behavior of the KCC Bounce method
         /// </summary>
         [Test]
-        public void Validate_KCCSnapUpAction()
+        public void Validate_KCCSnapUpAction([NUnit.Framework.Range(0.1f, 2f, 0.1f)] float snapUpDistance)
         {
             SetupColliderCast(new[]
             {
                 // First hit should be simulating hitting a step slightly above foot position
-                (true, SetupRaycastHitMock(distance: KCCUtils.Epsilon, point: Vector3.up * 0.05f, normal: Vector3.back)),
+                (true, SetupRaycastHitMock(distance: 0.1f, point: Vector3.up * snapUpDistance / 2, normal: Vector3.back)),
                 // Next hit should not collide with anything as we are above the step
                 (false, SetupRaycastHitMock()),
             });
@@ -188,7 +188,7 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode
             colliderCastMock.Setup(mock => mock.GetBottom(It.IsAny<Vector3>(), It.IsAny<Quaternion>())).Returns(Vector3.zero);
 
             // Simulate bounces
-            var bounces = GetBounces(Vector3.zero, Vector3.forward).ToList();
+            var bounces = GetBounces(Vector3.zero, Vector3.forward, verticalSnapUp: snapUpDistance).ToList();
 
             // Validate bounce properties
             Assert.IsTrue(bounces.Count == 3, $"Expected to find {3} bounce but instead found {bounces.Count}");

--- a/Assets/Tests/PlayMode/KCCUtilsScenarioTests.cs
+++ b/Assets/Tests/PlayMode/KCCUtilsScenarioTests.cs
@@ -236,7 +236,7 @@ namespace nickmaltbie.OpenKCC.Tests.PlayMode
         /// <param name="angle">Angle of wall to test player jitter against.</param>
         /// <returns>Enumerator of unity events for the test.</returns>
         [UnityTest]
-        public IEnumerator TestKCCMovementJitterOnAngle([NUnit.Framework.Range(15, 179, 15)] float angle, [Values(10, 20)]float wallLength)
+        public IEnumerator TestKCCMovementJitterOnAngle([NUnit.Framework.Range(15, 179, 15)] float angle, [Values(10, 20)] float wallLength)
         {
             // Setup a wall at the given angle
             ProBuilderMesh angledWall1 = ShapeGenerator.GenerateCube(PivotLocation.FirstCorner, new Vector3(0.1f, 2, wallLength));
@@ -251,8 +251,8 @@ namespace nickmaltbie.OpenKCC.Tests.PlayMode
             angledWall1.transform.position = new Vector3(-0.1f, 0, wallLength);
             angledWall2.transform.position = new Vector3(-0.1f, 0, wallLength);
 
-            angledWall1.transform.rotation = Quaternion.Euler(0, 180 - angle/2, 0);
-            angledWall2.transform.rotation = Quaternion.Euler(0, 180 + angle/2, 0);
+            angledWall1.transform.rotation = Quaternion.Euler(0, 180 - angle / 2, 0);
+            angledWall2.transform.rotation = Quaternion.Euler(0, 180 + angle / 2, 0);
 
             RegisterGameObject(angledWall1.gameObject);
             RegisterGameObject(angledWall2.gameObject);
@@ -265,13 +265,14 @@ namespace nickmaltbie.OpenKCC.Tests.PlayMode
 
             Assert.IsTrue(bounces.Count >= 2, $"Was expecting to find at least {2} bounces but instead found {bounces.Count}");
 
-            foreach (var bounce in bounces.AsEnumerable().Reverse().Skip(1))
+            foreach (KCCBounce bounce in bounces.AsEnumerable().Reverse().Skip(1))
             {
                 Assert.IsTrue(
-                    bounce.action == KCCUtils.MovementAction.Bounce || 
+                    bounce.action == KCCUtils.MovementAction.Bounce ||
                     bounce.action == KCCUtils.MovementAction.Move,
                     $"Expected to find action {KCCUtils.MovementAction.Bounce} or {KCCUtils.MovementAction.Move} but instead found {bounce.action}");
             }
+
             KCCValidation.ValidateKCCBounce(bounces[bounces.Count - 1], KCCUtils.MovementAction.Stop);
 
             Vector3 deltaMove = bounces[bounces.Count - 1].finalPosition - playerPosition.position;
@@ -284,7 +285,6 @@ namespace nickmaltbie.OpenKCC.Tests.PlayMode
                 (deltaMove.z <= 0.01f &&
                  bounces[bounces.Count - 1].finalPosition.z - wallLength <= wallLength / 10);
 
-
             // The player should continue to move forward and either bounce
             //  or stop but never move backwards and start "jittering"
             while (bounces.Count > 1 && !complete())
@@ -295,13 +295,13 @@ namespace nickmaltbie.OpenKCC.Tests.PlayMode
 
                 // Assert all actions are bounces and that those bounces are forward
                 // Except the last one.
-                foreach (var bounce in bounces.AsEnumerable().Reverse().Skip(1))
+                foreach (KCCBounce bounce in bounces.AsEnumerable().Reverse().Skip(1))
                 {
                     Assert.IsTrue(
                         Vector3.Dot(bounce.Movement, Vector3.forward) >= 0,
                         $"Player must mover in forward direction but instead moved in direction {bounce.Movement.ToString("F3")}");
                     Assert.IsTrue(
-                        bounce.action == KCCUtils.MovementAction.Bounce || 
+                        bounce.action == KCCUtils.MovementAction.Bounce ||
                         bounce.action == KCCUtils.MovementAction.Move,
                         $"Expected to find action {KCCUtils.MovementAction.Bounce} or {KCCUtils.MovementAction.Move} but instead found {bounce.action}");
                 }

--- a/Assets/Tests/PlayMode/KCCUtilsScenarioTests.cs
+++ b/Assets/Tests/PlayMode/KCCUtilsScenarioTests.cs
@@ -224,8 +224,87 @@ namespace nickmaltbie.OpenKCC.Tests.PlayMode
 
             Debug.Log($"initialPosition: {bounces[0].initialPosition}, finalPosition: {bounces[0].finalPosition}, movement: {bounces[0].Movement}");
 
-            TestUtils.AssertInBounds(bounces[0].Movement, Vector3.forward * (distance - 3), KCCUtils.Epsilon * 5);
-            TestUtils.AssertInBounds(lastBounce.finalPosition, bounces[0].finalPosition, KCCUtils.Epsilon * 5);
+            TestUtils.AssertInBounds(bounces[0].Movement, Vector3.forward * (distance - 3), 0.1f);
+            TestUtils.AssertInBounds(lastBounce.finalPosition, bounces[0].finalPosition, 0.1f);
+        }
+
+        /// <summary>
+        /// Evaluate and test for player jitter when moving against an angled wall.
+        /// When the player hits the wall, their consecutive movements should NOT
+        /// make them jitter back and forward due to sliding between the angle.
+        /// </summary>
+        /// <param name="angle">Angle of wall to test player jitter against.</param>
+        /// <returns>Enumerator of unity events for the test.</returns>
+        [UnityTest]
+        public IEnumerator TestKCCMovementJitterOnAngle([NUnit.Framework.Range(15, 179, 15)] float angle, [Values(10, 20)]float wallLength)
+        {
+            // Setup a wall at the given angle
+            ProBuilderMesh angledWall1 = ShapeGenerator.GenerateCube(PivotLocation.FirstCorner, new Vector3(0.1f, 2, wallLength));
+            ProBuilderMesh angledWall2 = ShapeGenerator.GenerateCube(PivotLocation.FirstCorner, new Vector3(0.1f, 2, wallLength));
+
+            angledWall1.GetComponent<MeshRenderer>().material = new Material(Shader.Find("Universal Render Pipeline/Lit"));
+            angledWall2.GetComponent<MeshRenderer>().material = new Material(Shader.Find("Universal Render Pipeline/Lit"));
+
+            angledWall1.gameObject.AddComponent<MeshCollider>();
+            angledWall2.gameObject.AddComponent<MeshCollider>();
+
+            angledWall1.transform.position = new Vector3(-0.1f, 0, wallLength);
+            angledWall2.transform.position = new Vector3(-0.1f, 0, wallLength);
+
+            angledWall1.transform.rotation = Quaternion.Euler(0, 180 - angle/2, 0);
+            angledWall2.transform.rotation = Quaternion.Euler(0, 180 + angle/2, 0);
+
+            RegisterGameObject(angledWall1.gameObject);
+            RegisterGameObject(angledWall2.gameObject);
+
+            yield return new WaitForFixedUpdate();
+
+            // First time player moves, they should move forward and bounce off the first angled wall
+            // Then they will slide into the second wall, and stop.
+            var bounces = GetBounces(Vector3.forward * wallLength).ToList();
+
+            Debug.Log(string.Join("\n", bounces));
+
+            Assert.IsTrue(bounces.Count >= 2, $"Was expecting to find at least {2} bounces but instead found {bounces.Count}");
+
+            foreach (var bounce in bounces.AsEnumerable().Reverse().Skip(1))
+            {
+                Assert.IsTrue(
+                    bounce.action == KCCUtils.MovementAction.Bounce || 
+                    bounce.action == KCCUtils.MovementAction.Move,
+                    $"Expected to find action {KCCUtils.MovementAction.Bounce} or {KCCUtils.MovementAction.Move} but instead found {bounce.action}");
+            }
+            KCCValidation.ValidateKCCBounce(bounces[bounces.Count - 1], KCCUtils.MovementAction.Stop);
+
+            playerPosition.position = bounces[bounces.Count - 1].finalPosition;
+
+            int moves = 0;
+
+            // The player should continue to move forward and either bounce
+            //  or stop but never move backwards and start "jittering"
+            while (bounces.Count > 1 && moves < 1000)
+            {
+                bounces = GetBounces(Vector3.forward * wallLength).ToList();
+
+                // Assert all actions are bounces and that those bounces are forward
+                // Except the last one.
+                foreach (var bounce in bounces.AsEnumerable().Reverse().Skip(1))
+                {
+                    Assert.IsTrue(
+                        Vector3.Dot(bounce.Movement, Vector3.forward) >= 0,
+                        $"Player must mover in forward direction but instead moved in direction {bounce.Movement.ToString("F3")}");
+                    Assert.IsTrue(
+                        bounce.action == KCCUtils.MovementAction.Bounce || 
+                        bounce.action == KCCUtils.MovementAction.Move,
+                        $"Expected to find action {KCCUtils.MovementAction.Bounce} or {KCCUtils.MovementAction.Move} but instead found {bounce.action}");
+                }
+
+                moves++;
+            }
+
+            // Assert that the last action was just a stop.
+            Assert.IsTrue(moves <= 1000, "Expected player to reach end of angle before 1000 bounces");
+            KCCValidation.ValidateKCCBounce(bounces[bounces.Count - 1], KCCUtils.MovementAction.Stop);
         }
 
         /// <summary>
@@ -366,7 +445,9 @@ namespace nickmaltbie.OpenKCC.Tests.PlayMode
                         Assert.IsTrue(
                             stepUp.action == KCCUtils.MovementAction.SnapUp || stepUp.action == KCCUtils.MovementAction.Bounce,
                             $"Expected to find action {KCCUtils.MovementAction.SnapUp} or {KCCUtils.MovementAction.Bounce} but instead found {stepUp.action}");
-                        Assert.IsTrue(Vector3.Dot(stepUp.Movement, Vector3.forward) > 0.0f);
+                        Assert.IsTrue(Vector3.Dot(
+                            stepUp.Movement, Vector3.forward) >= 0.0f,
+                            $"Expected player movement to be forward but instead found {stepUp.Movement.ToString("F3")}");
                         if (stepUp.action == KCCUtils.MovementAction.SnapUp)
                         {
                             snapUpCount++;


### PR DESCRIPTION
# Description

Fixed bug with KCC angle jitter where if the player walks into an angled wall, they will jitter between the two edges.

This bug was noted as part of Closes #42 
Main change to fix this bug happened in the KCCUtils:
```C#
// Continue computing while there is momentum and bounces remaining
while (momentum.magnitude >= Epsilon && bounces <= config.MaxBounces)
{
    KCCBounce bounce = SingleKCCBounce(position, momentum, movement, rotation, config);
    ....
    else if (Vector3.Dot(bounce.Movement, movement) < 0)
    {
        break;
    }
    ....
}
```

# How Has This Been Tested?

Created some unit and integration tests to have the player move against two walls angled in a corner in the test case `TestKCCMovementJitterOnAngle` as well as unit test scenarios to ensure the code is reachable in the test `Verify_KCCNoJitterBackwards`.

These tests did fail for angles over 90 degrees when the new behavior was disabled showing that this new patch does fix for jittery movement in the scenario described in Issue #42 
![image](https://user-images.githubusercontent.com/3240136/170848790-63f1f61d-81b6-40a5-811b-050bfe72163a.png)

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that demonstrate the new feature or bugfix
- [x] New and existing unit and integrations tests pass locally with my changes
