### PR TITLE
Removed Semvar Updates from Deploy Workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,73 +3,21 @@ name: Build and Deploy WebGL
 concurrency: production-${{ github.ref }}
 
 on:
-  pull_request:
-    branches: 
-      - main
-    types: [closed]
+  push:
+    branches:
+      - 'main'
 
 env:
   UNITY_LICENSE: ${{ secrets.UNITY_LICENSE_2021_1 }}
 
 jobs:
-  update-semver:
-    name: Update Semantic Version of Project
-    runs-on: ubuntu-latest
-    outputs:
-      commit_hash: ${{ steps.commit_changes.outputs.commit_long_sha }}
-
-    steps:
-      # You must ALWAYS checkout your repo so that actions in the workflow can use it.
-      - name: Checkout 
-        uses: actions/checkout@v3
-        with:
-          ref: main
-          token: ${{ secrets.PAT }}
-      - uses: ./.github/actions/git-lfs-cache
-      - run: git config --local core.hooksPath .githooks
-
-      - name: Find ProjectSettings.asset & increment its bundleVersion number
-        uses: AlexHolderDeveloper/UnityAutomatedSemver@v1.02
-        id: semver-update
-        with:
-          semver-update-type: 'patch' # version number: "major.minor.patch"
-
-      # Validate that the number has been incremented correctly.
-      - name: Get the new semver number
-        run: echo "The new semver number for this Unity project is ${{ steps.semver-update.outputs.semver-number }}"
-
-      - name: Commit Changes
-        id: commit_changes
-        uses: EndBug/add-and-commit@v9
-        with:
-          author_name: "github-actions[bot]"
-          author_email: "github-actions[bot]@users.noreply.github.com"
-          commit: '--no-verify --signoff'
-          message: "Updated semver to ${{ steps.semver-update.outputs.semver-number }} for PR #${{ github.event.pull_request.number }}."
-          add: 'ProjectSettings/ProjectSettings.asset'
-          push: false
-
-      # Commit & push the updated semver number back into the repo. Yes, you have to fetch & pull in your local workstation after this step is done.
-      - id: commit_and_push
-        name: Push changed files back to repo
-        uses: CasperWA/push-protected@v2.10.0
-        with:
-          token: ${{ secrets.PAT }}
-          branch: main
-          unprotect_reviews: true
-          timeout: 30
-          sleep: 30
-
   build-and-deploy-app:
     name: Build and Deploy for Product
-    needs: update-semver
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ needs.update-semver.outputs.commit_hash }}
       - uses: ./.github/actions/git-lfs-cache
       - uses: ./.github/actions/unity-library-cache
         with:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
   push:
     branches:
+      - 'main'
       - 'push-action/**'
 
 env:

--- a/.github/workflows/tests-validation.yml
+++ b/.github/workflows/tests-validation.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches:
+      - 'main'
       - 'push-action/**'
 
 env:


### PR DESCRIPTION
# Description

Updated deploy to no longer include semvar updates. These semvar updates won't be as trivial when the project changes to a package-based model. So, to prepare for that change, I will remove the automated semvar update and simply have the project build each time main is updated.

The main reason this change is nice is that it greatly reduces the complexity of CI/CD for deploying as all the required checks are validated whenever a PR merge is validated. since a semantic version change requires updating the whole project and re-running the validation despite no changes (and adding in the logic to skip these steps if only the project settings has changed would also be a bit difficult and complex). 

# How Has This Been Tested?

Tested these changes as part of setting up the same workflow in my ScreenManager project - https://github.com/nicholas-maltbie/ScreenManager/pull/14/files#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that demonstrate the new feature or bugfix
- [x] New and existing unit and integrations tests pass locally with my changes
