### PR TITLE
DocFx Fixed Scripts Relative Path

### DIFF
--- a/Documentation/templates/mermaid/partials/scripts.tmpl.partial
+++ b/Documentation/templates/mermaid/partials/scripts.tmpl.partial
@@ -1,6 +1,6 @@
-<script type="text/javascript" src="../../styles/docfx.vendor.js"></script>
-<script type="text/javascript" src="../../styles/docfx.js"></script>
-<script type="text/javascript" src="../../styles/main.js"></script>
+<script type="text/javascript" src="{{_rel}}styles/docfx.vendor.js"></script>
+<script type="text/javascript" src="{{_rel}}styles/docfx.js"></script>
+<script type="text/javascript" src="{{_rel}}styles/main.js"></script>
 
 <!-- Derived from https://blog.christian-schou.dk/how-to-produce-static-documentation-using-docfx/#including-diagrams-in-your-documentation-mermaid-with-docfx !-->
 <!-- mermaid support -->


### PR DESCRIPTION
# Description

Fixed scripts by based on default by adding `{{_rel}}` to the start of the scripts path to account for the relative path 
of the base site (which in this case would be `nickmaltbie.com/OpenKCC/docs`

# How Has This Been Tested?

Tested changes local build to ensure it works as expected.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that demonstrate the new feature or bugfix
- [x] New and existing unit and integrations tests pass locally with my changes
