### PR TITLE
Disable Movement While in Menu

### DIFF
--- a/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/KCCStateMachine.cs
+++ b/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/KCCStateMachine.cs
@@ -358,7 +358,8 @@ namespace nickmaltbie.OpenKCC.Character
         /// <inheritdoc/>
         public override void Update()
         {
-            Vector2 moveVector = moveAction.action.ReadValue<Vector2>();
+            Vector2 moveVector = PlayerInputUtils.playerMovementState == PlayerInputState.Deny ?
+                moveVector = Vector3.zero : moveAction.action.ReadValue<Vector2>();
             InputMovement = new Vector3(moveVector.x, 0, moveVector.y);
             RaiseEvent(InputMovement.magnitude >= KCCUtils.Epsilon ?
                 MoveInput.Instance as IEvent : StopMoveInput.Instance as IEvent);

--- a/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Character/KCCStateMachineTests.cs
+++ b/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Character/KCCStateMachineTests.cs
@@ -180,6 +180,28 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode.Character
         }
 
         [Test]
+        public void Validate_KCCStateMachine_PlayerInputUtilsFlags()
+        {
+            TestUtils.SetupCastSelf(colliderCastMock, distance: 0.001f, normal: Vector3.up, didHit: true);
+            Set(moveStick, Vector2.up);
+            PlayerInputUtils.playerMovementState = PlayerInputState.Deny;
+
+            kccStateMachine.Update();
+            TestUtils.AssertInBounds(kccStateMachine.InputMovement, Vector3.zero);
+
+            Assert.AreEqual(kccStateMachine.CurrentState, typeof(KCCStateMachine.IdleState));
+
+            kccStateMachine.FixedUpdate();
+
+            Assert.AreEqual(kccStateMachine.CurrentState, typeof(KCCStateMachine.IdleState));
+            Assert.IsTrue(kccStateMachine.groundedState.StandingOnGround);
+            Assert.IsFalse(kccStateMachine.groundedState.Sliding);
+            Assert.IsFalse(kccStateMachine.groundedState.Falling);
+
+            PlayerInputUtils.playerMovementState = PlayerInputState.Allow;
+        }
+
+        [Test]
         public void Validate_KCCStateMachine_Values(
             [Random(2)] int maxBounces,
             [Random(2)] float pushDecay,


### PR DESCRIPTION
# Description

Disabled player input in KCCStateMachine to disable input movement whenever the player opens the menu.

# How Has This Been Tested?

verified changes locally as well as using an automated test.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that demonstrate the new feature or bugfix
- [x] New and existing unit and integrations tests pass locally with my changes
