### PR TITLE
Allow Re-Use from Secure Connection Server

### DIFF
--- a/Assets/Samples/NetcodeExample/Scripts/NetworkControls.cs
+++ b/Assets/Samples/NetcodeExample/Scripts/NetworkControls.cs
@@ -179,6 +179,11 @@ namespace nickmaltbie.NetworkStateMachineUnity.ExampleAnim
                 transport.SecureConnection = true;
                 transport.CertificateBase64String = Convert.ToBase64String(cert.Export(X509ContentType.Pkcs12, string.Empty));
             }
+            else
+            {
+                transport.SecureConnection = false;
+                transport.CertificateBase64String = string.Empty;
+            }
         }
 
         public void StartNetworkManager(NMActionType action)


### PR DESCRIPTION
# Description

Added flag to allow for re-using a server from non-secure to secure connection for communication via https.

# How Has This Been Tested?

Tested client locally to ensure it works as expected.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that demonstrate the new feature or bugfix
- [x] New and existing unit and integrations tests pass locally with my changes
