### PR TITLE
Added Flag for TestCoverage Results

### DIFF
--- a/.github/workflows/tests-validation.yml
+++ b/.github/workflows/tests-validation.yml
@@ -31,10 +31,60 @@ jobs:
           testMode: All
           checkName: All Test Results
           customParameters: -testFilter "nickmaltbie.OpenKCC.Tests.*" -nographics
-          coverageOptions: 'generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;assemblyFilters:+nickmaltbie.OpenKCC*;pathFilters:+**/Packages/**,-**/Tests/**'
+          coverageOptions: 'generateBadgeReport;generateHtmlReport;assemblyFilters:+nickmaltbie.OpenKCC,+nickmaltbie.OpenKCC.netcode,-nickmaltbie.OpenKCC.Tests.*;dontClear'
 
       - name: Copy Coverage Results
         run: |
           mkdir -p allResults
           sudo cp -r ${{ steps.tests.outputs.coveragePath }} allResults/CodeCoverage
           sudo cp -r ${{ steps.tests.outputs.artifactsPath }} allResults/artifacts
+
+      - name: Upload Results
+        uses: actions/upload-artifact@v3
+        with:
+          name: Test & Coverage Results
+          path: allResults
+          retention-days: 7
+
+      - name: Find Coverage
+        id: coverage
+        run: |
+          echo ::set-output name=COVERAGE_FILE::$(find ${{ steps.tests.outputs.coveragePath }} -name "Summary.xml")
+          find ${{ steps.tests.outputs.coveragePath }} -name "*.xml"
+          ls -lah .
+          ls -lah ${{ steps.tests.outputs.coveragePath }}
+
+      - name: Line Coverage
+        id: LineCoverage
+        uses: QwerMike/xpath-action@v1
+        with:
+          filename: "${{ steps.coverage.outputs.COVERAGE_FILE }}"
+          expression: '//CoverageReport/Summary/Linecoverage/text()'
+
+      # - name: Branch Coverage
+      #   id: branchCoverage
+      #   uses: QwerMike/xpath-action@v1
+      #   with:
+      #     filename: "${{ env.COVERAGE_FILE }}"
+      #     expression: '//CoverageSession/Summary/@branchCoverage'
+
+      - name: Parse Coverage
+        id: ParseCoverage
+        run: |
+          echo ::set-output name=LINE_COVERAGE::$(cut -d "=" -f2- <<< ${{ steps.LineCoverage.outputs.result }})
+
+      - name: Add PR Comment
+        uses: mshick/add-pr-comment@v1
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          message: |
+            Test Coverage Results for ${{ matrix.testMode }}:
+            Line Coverage: ${{ steps.ParseCoverage.outputs.LINE_COVERAGE }}%
+            Link to run results: [https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
+          allow-repeats: false # This is the default
+
+      # - name: Assert Coverage
+      #   run: |
+      #     python3 -c "assert ${{ steps.ParseCoverage.outputs.LINE_COVERAGE }} >= 100, 'Line Coverage must be 100%, is only ${{ env.LINE_COVERAGE }}%'"

--- a/.github/workflows/tests-validation.yml
+++ b/.github/workflows/tests-validation.yml
@@ -31,7 +31,7 @@ jobs:
           testMode: All
           checkName: All Test Results
           customParameters: -testFilter "nickmaltbie.OpenKCC.Tests.*" -nographics
-          coverageOptions: 'generateBadgeReport;generateHtmlReport;generateTestReferences;assemblyFilters:+nickmaltbie.OpenKCC,+nickmaltbie.OpenKCC.netcode,-nickmaltbie.OpenKCC.Tests.*;dontClear'
+          coverageOptions: 'generateHtmlReport;assemblyFilters:+nickmaltbie.OpenKCC,+nickmaltbie.OpenKCC.netcode,-nickmaltbie.OpenKCC.Tests.*;dontClear'
 
       - name: Copy Coverage Results
         run: |

--- a/.github/workflows/tests-validation.yml
+++ b/.github/workflows/tests-validation.yml
@@ -31,7 +31,7 @@ jobs:
           testMode: All
           checkName: All Test Results
           customParameters: -testFilter "nickmaltbie.OpenKCC.Tests.*" -nographics
-          coverageOptions: 'generateBadgeReport;generateHtmlReport;assemblyFilters:+nickmaltbie.OpenKCC,+nickmaltbie.OpenKCC.netcode,-nickmaltbie.OpenKCC.Tests.*;dontClear'
+          coverageOptions: 'generateBadgeReport;generateHtmlReport;generateTestReferences;assemblyFilters:+nickmaltbie.OpenKCC,+nickmaltbie.OpenKCC.netcode,-nickmaltbie.OpenKCC.Tests.*;dontClear'
 
       - name: Copy Coverage Results
         run: |

--- a/Packages/com.nickmaltbie.openkcc/README.md
+++ b/Packages/com.nickmaltbie.openkcc/README.md
@@ -41,18 +41,18 @@ projects to your project.
 
 Install the latest version of the project by importing a project via git
 at this URL:
-`https://github.com/nicholas-maltbie/OpenKCC.git#release/latest`
+`git+https://github.com/nicholas-maltbie/OpenKCC.git#release/latest`
 
 If you want to reference a specific tag of the project such as version `v1.0.1`,
 add a `#release/v1.0.1` to the end of the git URL to download the package
 from th auto-generated branch for that release. An example of importing `v1.0.1`
 would look like this:
-`https://github.com/nicholas-maltbie/openkcc.git#release/v1.0.1`.
+`git+https://github.com/nicholas-maltbie/openkcc.git#release/v1.0.1`.
 
 To use the latest release, simply reference:
 
 ```text
-https://github.com/nicholas-maltbie/openkcc.git#release/latest
+git+https://github.com/nicholas-maltbie/openkcc.git#release/latest
 ```
 
 For a full list of all tags, check the [OpenKCC Tags](https://github.com/nicholas-maltbie/ScreenManager/tags)
@@ -103,7 +103,7 @@ manager will be able to download it from the registry at
   "com.nickmaltbie.openkcc": "1.0.1",
   "com.nickmaltbie.screenmanager": "3.0.0",
   "com.nickmaltbie.statemachineunity": "1.1.0",
-  "com.nickmaltbie.testutilsunity": "0.0.2",
+  "com.nickmaltbie.testutilsunity": "1.0.0",
   "com.unity.inputsystem": "1.0.0",
   "com.unity.textmeshpro": "3.0.0"
 }

--- a/Packages/com.nickmaltbie.openkcc/package.json
+++ b/Packages/com.nickmaltbie.openkcc/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "com.nickmaltbie.screenmanager": "3.0.0",
     "com.nickmaltbie.statemachineunity": "1.1.0",
-    "com.nickmaltbie.testutilsunity": "0.0.2",
+    "com.nickmaltbie.testutilsunity": "1.0.0",
     "com.unity.inputsystem": "1.0.0",
     "com.unity.textmeshpro": "3.0.0"
   },

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -25,7 +25,7 @@
     "com.unity.recorder": "3.0.3",
     "com.unity.render-pipelines.universal": "12.1.7",
     "com.unity.test-framework": "2.0.1-pre.18",
-    "com.unity.testtools.codecoverage": "1.0.1",
+    "com.unity.testtools.codecoverage": "1.2.2",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.6.4",
     "com.unity.toolchain.win-x86_64-linux-x86_64": "2.0.3",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -26,7 +26,7 @@
       "dependencies": {
         "com.nickmaltbie.screenmanager": "3.0.0",
         "com.nickmaltbie.statemachineunity": "1.1.0",
-        "com.nickmaltbie.testutilsunity": "0.0.2",
+        "com.nickmaltbie.testutilsunity": "1.0.0",
         "com.unity.inputsystem": "1.0.0",
         "com.unity.textmeshpro": "3.0.0"
       }
@@ -307,7 +307,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.testtools.codecoverage": {
-      "version": "1.0.1",
+      "version": "1.2.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/README.md
+++ b/README.md
@@ -41,18 +41,18 @@ projects to your project.
 
 Install the latest version of the project by importing a project via git
 at this URL:
-`https://github.com/nicholas-maltbie/OpenKCC.git#release/latest`
+`git+https://github.com/nicholas-maltbie/OpenKCC.git#release/latest`
 
 If you want to reference a specific tag of the project such as version `v1.0.1`,
 add a `#release/v1.0.1` to the end of the git URL to download the package
 from th auto-generated branch for that release. An example of importing `v1.0.1`
 would look like this:
-`https://github.com/nicholas-maltbie/openkcc.git#release/v1.0.1`.
+`git+https://github.com/nicholas-maltbie/openkcc.git#release/v1.0.1`.
 
 To use the latest release, simply reference:
 
 ```text
-https://github.com/nicholas-maltbie/openkcc.git#release/latest
+git+https://github.com/nicholas-maltbie/openkcc.git#release/latest
 ```
 
 For a full list of all tags, check the [OpenKCC Tags](https://github.com/nicholas-maltbie/ScreenManager/tags)
@@ -103,7 +103,7 @@ manager will be able to download it from the registry at
   "com.nickmaltbie.openkcc": "1.0.1",
   "com.nickmaltbie.screenmanager": "3.0.0",
   "com.nickmaltbie.statemachineunity": "1.1.0",
-  "com.nickmaltbie.testutilsunity": "0.0.2",
+  "com.nickmaltbie.testutilsunity": "1.0.0",
   "com.unity.inputsystem": "1.0.0",
   "com.unity.textmeshpro": "3.0.0"
 }


### PR DESCRIPTION
# Description

Updated code coverage package version and added the `dontClear` flag to the test validation workflow to ensure that editmode and playmode tests are combined correctly.

# How Has This Been Tested?

Validated workflow locally with the following powershell script:

```PowerShell
Start-Process -FilePath 'C:\Program Files\Unity\Hub\Editor\2021.3.11f1\Editor\Unity.exe' `
    -ArgumentList @("-batchmode", "-projectPath", "D:\Projects\OpenKCC\", `
    "-runTests", "-testPlatform", "editmode", "-enableCodeCoverage", "-debugCodeOptimization", `
    "-coverageResultsPath", "D:\Projects\OpenKCC\CodeCoverage", `
    "-coverageOptions", "generateBadgeReport;generateHtmlReport;assemblyFilters:+nickmaltbie.OpenKCC,+nickmaltbie.OpenKCC.netcode,-nickmaltbie.OpenKCC.Tests.*;dontClear", `
    "-testResults", "D:\Projects\OpenKCC\CodeCoverage\EditMode.xml", "-testFilter", "nickmaltbie.OpenKCC.Tests.*") -Wait

Start-Process -FilePath 'C:\Program Files\Unity\Hub\Editor\2021.3.11f1\Editor\Unity.exe' `
    -ArgumentList @("-batchmode", "-projectPath", "D:\Projects\OpenKCC\", `
    "-runTests", "-testPlatform", "playmode", "-enableCodeCoverage", "-debugCodeOptimization", `
    "-coverageResultsPath", "D:\Projects\OpenKCC\CodeCoverage", `
    "-coverageOptions", "generateBadgeReport;generateHtmlReport;assemblyFilters:+nickmaltbie.OpenKCC,+nickmaltbie.OpenKCC.netcode,-nickmaltbie.OpenKCC.Tests.*;dontClear", `
    "-testResults", "D:\Projects\OpenKCC\CodeCoverage\PlayMode.xml", "-testFilter", "nickmaltbie.OpenKCC.Tests.*") -Wait

Start-Process -FilePath 'C:\Program Files\Unity\Hub\Editor\2021.3.11f1\Editor\Unity.exe' `
    -ArgumentList @("-batchmode", "-projectPath", "D:\Projects\OpenKCC\", `
    "-enableCodeCoverage", "-debugCodeOptimization", `
    "-coverageResultsPath", "D:\Projects\OpenKCC\CodeCoverage", `
    "-coverageOptions", "generateBadgeReport;generateHtmlReport;assemblyFilters:+nickmaltbie.OpenKCC,+nickmaltbie.OpenKCC.netcode,-nickmaltbie.OpenKCC.Tests.*;dontClear", `
    "-coverageResults", "D:\Projects\OpenKCC\CodeCoverage", "-quit") -Wait
```

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that demonstrate the new feature or bugfix
- [x] New and existing unit and integrations tests pass locally with my changes
