### PR TITLE
Follow Ground on Late Update

### DIFF
--- a/Packages/com.nickmaltbie.openkcc.netcode/OpenKCC.netcode/Character/NetworkKCC.cs
+++ b/Packages/com.nickmaltbie.openkcc.netcode/OpenKCC.netcode/Character/NetworkKCC.cs
@@ -291,6 +291,14 @@ namespace nickmaltbie.OpenKCC.netcode.Character
             }
         }
 
+        public override void LateUpdate()
+        {
+            relativeParentConfig.FollowGround(transform);
+            transform.position += config.ColliderCast.PushOutOverlapping(transform.position, transform.rotation, config.maxPushSpeed * unityService.deltaTime);
+
+            base.LateUpdate();
+        }
+
         public override void FixedUpdate()
         {
             GetComponent<Rigidbody>().isKinematic = true;
@@ -308,7 +316,6 @@ namespace nickmaltbie.OpenKCC.netcode.Character
             if (IsOwner)
             {
                 ReadPlayerMovement();
-                relativeParentConfig.FollowGround(transform);
             }
 
             AttachedAnimator.SetFloat("MoveX", animationMove.Value.x);


### PR DESCRIPTION
# Description

Changed NetworkKCC to follow the ground on a late update frame so that the player will move with the ground and not have their feet visually clip through the ground

# How Has This Been Tested?

Tested changes locally with player client to ensure player doesn't clip into platform.

Will have to update the relative parent transform to follow the buffer like the network transform so other players don't look like they are clipping into the ground either... but that's a future update's problem.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that demonstrate the new feature or bugfix
- [x] New and existing unit and integrations tests pass locally with my changes
