### PR TITLE
Mole Sample Muiltiplayer Fixes

### DIFF
--- a/Assets/Editor/ScriptBatch.cs
+++ b/Assets/Editor/ScriptBatch.cs
@@ -61,6 +61,14 @@ public class ScriptBatch : IPostprocessBuildWithReport, IPreprocessBuildWithRepo
     };
 
     /// <summary>
+    /// Gets the list of scenes to use in the mole sample build.
+    /// </summary>
+    public static string[] MoleSampleGameScenes => new[]
+    {
+        System.IO.Path.Combine(ScriptBatch.AssetDirectory, "Samples", "MoleKCCSample", "MoleScene.unity")
+    };
+
+    /// <summary>
     /// Gets the list of scenes to use in the netcode build.
     /// </summary>
     public static string[] NetcodeGameScenes => new[]
@@ -242,6 +250,30 @@ public class ScriptBatch : IPostprocessBuildWithReport, IPreprocessBuildWithRepo
 
         // Build player.
         BuildPipeline.BuildPlayer(GameScenes, path + $"/{AppName}.x86_64", BuildTarget.StandaloneLinux64, BuildOptions.Development);
+    }
+
+    /// <summary>
+    /// Create a build for Mole Sample with windows 64 version and IL2CPP backend.
+    /// </summary>
+    [MenuItem("Build/Mole Sample/Demo/Windows64 Build")]
+    public static void MoleWindowsBuild()
+    {
+        PlayerSettings.SetScriptingBackend(BuildTargetGroup.Standalone, ScriptingImplementation.IL2CPP);
+
+        var options = new BuildPlayerOptions
+        {
+            scenes = MoleSampleGameScenes,
+            locationPathName = Path.Combine(
+                BuildDirectory,
+                $"MoleSample-Win64-{VersionNumber}",
+                $"{AppName}.exe"),
+            targetGroup = BuildTargetGroup.Standalone,
+            target = BuildTarget.StandaloneWindows64,
+            options = BuildOptions.Development
+        };
+
+        // Build player.
+        BuildPipeline.BuildPlayer(options);
     }
 
     /// <summary>

--- a/Packages/com.nickmaltbie.openkcc.netcode/CHANGELOG.md
+++ b/Packages/com.nickmaltbie.openkcc.netcode/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## In Progress
 
+
+## [1.2.1] 2023-1-15
+
+* Removed rotation synchronization from the network relative transform.
+    Will overhaul the class in the future.
+* Small fixes to mole multiplayer synchronization and tails.
+
 ## [1.2.0] 2023-1-15
 
 * Setup basic mole character controller using the `MoleMovementEngine`

--- a/Packages/com.nickmaltbie.openkcc.netcode/OpenKCC.netcode/Utils/NetworkRelativeParent.cs
+++ b/Packages/com.nickmaltbie.openkcc.netcode/OpenKCC.netcode/Utils/NetworkRelativeParent.cs
@@ -29,7 +29,6 @@ namespace nickmaltbie.OpenKCC.netcode.Utils
         public NetworkObjectReference parentTransform;
         public Vector3 relativePosition;
         public Vector3 worldPos;
-        public Quaternion rotation;
 
         public void NetworkSerialize<T>(BufferSerializer<T> serializer) where T : IReaderWriter
         {
@@ -37,7 +36,6 @@ namespace nickmaltbie.OpenKCC.netcode.Utils
             serializer.SerializeValue(ref parentTransform);
             serializer.SerializeValue(ref relativePosition);
             serializer.SerializeValue(ref worldPos);
-            serializer.SerializeValue(ref rotation);
         }
     }
 }

--- a/Packages/com.nickmaltbie.openkcc.netcode/OpenKCC.netcode/Utils/NetworkRelativeTransform.cs
+++ b/Packages/com.nickmaltbie.openkcc.netcode/OpenKCC.netcode/Utils/NetworkRelativeTransform.cs
@@ -41,6 +41,16 @@ namespace nickmaltbie.OpenKCC.netcode.Utils
 
         public NetworkObject Floor { get; set; }
 
+        public Transform GetParent()
+        {
+            if (networkConstraint.Value.parentTransform.TryGet(out NetworkObject obj))
+            {
+                return obj.transform;
+            }
+
+            return null;
+        }
+
         public void UpdateState(RelativeParentConfig config)
         {
             Floor = config.previousParent?.GetComponent<NetworkObject>();
@@ -73,7 +83,6 @@ namespace nickmaltbie.OpenKCC.netcode.Utils
                         parentTransform = Floor,
                         relativePosition = relativePos,
                         worldPos = transform.position,
-                        rotation = transform.rotation,
                     };
                 }
                 else
@@ -85,7 +94,6 @@ namespace nickmaltbie.OpenKCC.netcode.Utils
                         parentTransform = default,
                         relativePosition = default,
                         worldPos = transform.position,
-                        rotation = transform.rotation,
                     };
                 }
             }

--- a/Packages/com.nickmaltbie.openkcc.netcode/package.json
+++ b/Packages/com.nickmaltbie.openkcc.netcode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.nickmaltbie.openkcc.netcode",
   "displayName": "Open KCC Netcode",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "unity": "2021.1",
   "unityRelease": "19f1",
   "description": "Open Source Kinematic Character Controller for NetCode.",

--- a/Packages/com.nickmaltbie.openkcc/package.json
+++ b/Packages/com.nickmaltbie.openkcc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.nickmaltbie.openkcc",
   "displayName": "Open KCC",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "unity": "2021.1",
   "unityRelease": "19f1",
   "description": "Open Source Kinematic Character Controller project.",

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -134,7 +134,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 1.2.0
+  bundleVersion: 1.2.1
   preloadedAssets:
   - {fileID: 11400000, guid: bd3a9f17edf6c454c870b081303aa6d2, type: 2}
   metroInputSource: 0

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -135,7 +135,8 @@ PlayerSettings:
     16:9: 1
     Others: 1
   bundleVersion: 1.2.0
-  preloadedAssets: []
+  preloadedAssets:
+  - {fileID: 11400000, guid: bd3a9f17edf6c454c870b081303aa6d2, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
# Description

Fixed mole multiplayer rotation synchronization and tail synchronization. The normal KCC syncs just the y axis via the camera cotnroller.

This should be shifted to the network relative transform class at some point in the future...


* Removed rotation synchronization from the network relative transform.
    Will overhaul the class in the future.
* Small fixes to mole multiplayer synchronization and tails.

# How Has This Been Tested?

Built project and tested via local build.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that demonstrate the new feature or bugfix
- [x] New and existing unit and integrations tests pass locally with my changes
