### PR TITLE
Move Through Ground Bug

### DIFF
--- a/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/Config/RelativeParentConfig.cs
+++ b/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/Config/RelativeParentConfig.cs
@@ -22,18 +22,37 @@ using UnityEngine;
 
 namespace nickmaltbie.OpenKCC.Character.Config
 {
+    /// <summary>
+    /// Relative parent configuration for saving
+    /// the position of an object relative to a given parent object.
+    /// </summary>
     [Serializable]
     public struct RelativeParentConfig
     {
+        /// <summary>
+        /// Relative position in local space.
+        /// </summary>
         public Vector3 relativePos;
+
+        /// <summary>
+        /// Previous parent for saving relative transform position.
+        /// </summary>
         public Transform previousParent;
 
+        /// <summary>
+        /// Reset the relative parent transform.
+        /// </summary>
         public void Reset()
         {
             relativePos = Vector3.zero;
             previousParent = null;
         }
 
+        /// <summary>
+        /// Move the transform's position
+        /// to be the same relative position to parent as the saved position.
+        /// </summary>
+        /// <param name="transform">Transform to move.</param>
         public void FollowGround(Transform transform)
         {
             if (previousParent != null)
@@ -42,6 +61,17 @@ namespace nickmaltbie.OpenKCC.Character.Config
             }
         }
 
+        /// <summary>
+        /// Update the moving ground state for a given
+        /// relative parent for some given movement.
+        /// </summary>
+        /// <param name="position">Position of object before moving.</param>
+        /// <param name="groundedState">Current grounded state of the object.</param>
+        /// <param name="delta">Delta that the object has moved.</param>
+        /// <param name="deltaTime">Delta time for update.</param>
+        /// <returns>The distance the player should be moved based
+        /// on moving ground. Will only be more than Vector3.zero if the ground
+        /// is moving and should not attach.</returns>
         public Vector3 UpdateMovingGround(Vector3 position, IKCCGrounded groundedState, Vector3 delta, float deltaTime)
         {
             if (groundedState.StandingOnGround && groundedState.Floor != null)

--- a/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/KCCMovementEngine.cs
+++ b/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/KCCMovementEngine.cs
@@ -309,7 +309,7 @@ namespace nickmaltbie.OpenKCC.Character
             CheckGrounded(snappedUp);
 
             Vector3 delta = transform.position - start;
-            transform.position += relativeParentConfig.UpdateMovingGround(transform.position, GroundedState, delta, unityService.fixedDeltaTime);
+            transform.position += relativeParentConfig.UpdateMovingGround(start, GroundedState, delta, unityService.fixedDeltaTime);
             relativeParentConfig.FollowGround(transform);
 
             previousPosition = transform.position;

--- a/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/KCCMovementEngine.cs
+++ b/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/KCCMovementEngine.cs
@@ -153,7 +153,7 @@ namespace nickmaltbie.OpenKCC.Character
         /// <summary>
         /// Relative parent configuration for following the ground.
         /// </summary>
-        protected RelativeParentConfig relativeParentConfig;
+        internal RelativeParentConfig relativeParentConfig;
 
         /// <summary>
         /// Current grounded state of the character.

--- a/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Character/KCCMovementEngineTests.cs
+++ b/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Character/KCCMovementEngineTests.cs
@@ -213,10 +213,10 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode.Character
             // with a radius of 0.5 units.
             GameObject ground = CreateGameObject();
             BoxCollider box = ground.AddComponent<BoxCollider>();
-            
+
             // Setup positions of ground and player.
             ground.transform.position = new Vector3(0, -0.5f, 0);
-            engine.transform.position = new Vector3(0,  1.5f, 0) + Vector3.up * KCCUtils.Epsilon;
+            engine.transform.position = new Vector3(0, 1.5f, 0) + Vector3.up * KCCUtils.Epsilon;
 
             // There should be three calls to the CastSelf
             // First call is for computing movement, simply return no hit

--- a/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Character/KCCMovementEngineTests.cs
+++ b/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Character/KCCMovementEngineTests.cs
@@ -200,5 +200,44 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode.Character
                 Assert.AreEqual(newNormal, engine.GroundedState.SurfaceNormal);
             }
         }
+
+        /// <summary>
+        /// Basic test to verify that the KCCMovementEngine won't
+        /// move into the ground when moving into the ground
+        /// with the relative parent config position.
+        /// </summary>
+        [Test]
+        public void Verify_KCCMovementEngine_NoMoveIntoGround()
+        {
+            // For this test pretend the player is a sphere
+            // with a radius of 0.5 units.
+            GameObject ground = CreateGameObject();
+            BoxCollider box = ground.AddComponent<BoxCollider>();
+            
+            ground.transform.position = new Vector3(0, -0.5f, 0);
+            engine.transform.position = new Vecotr3(0,  1.5f, 0) + Vector3.up * KCCUtils.Epsilon;
+
+            // There should be three calls to the CastSelf
+            // First call is for computing movement, simply return no hit
+            // Second call is for snapping to ground, should also return no hit
+            //   because I don't want to also test that code.
+            // Third call is for CheckGrounded, this is the important one.
+            // To make this similar to the real case, we need to return that the player
+            //   is just floating a little bit off the ground (0.001 units) and we should
+            //   be fine.
+            // We should compute the relative position of the player to be
+            // 0.5 units above the center of the box.
+
+            // Setup a basic collision between the player and the ground
+            // one meter below the player.
+            engine.MovePlayer(Vector3.down);
+
+            // Now assert that the relative position of the player
+            // to the ground is roughly 0.5 units above and that the
+            // absolute position of the player is about (0, 0.5, 0)
+
+            // After calling Update this should be true as well.
+            engine.Update();
+        }
     }
 }


### PR DESCRIPTION
# Description

Fixed a small bug where the player would snap into the floor for a single frame when becoming grounded due to an error in how the relative position to the ground was calculated. Issue was described with a nice example in issue #145 by @MTrecozzi thanks for submitting the issue.

Very simple fix, just needed to use the start position when calling `RelativeParentConfig.UpdateMovingGround` which excludes the current movement before computing the position of the player relative to the ground.

```C#
Vector3 delta = transform.position - start;

// Previous incorrect call
transform.position += relativeParentConfig.UpdateMovingGround(transform.position, GroundedState, delta, unityService.fixedDeltaTime);

// Improved call
transform.position += relativeParentConfig.UpdateMovingGround(start, GroundedState, delta, unityService.fixedDeltaTime);
relativeParentConfig.FollowGround(transform);
```

Old Behaviour:
![Snap-Through-Floor](https://user-images.githubusercontent.com/3240136/215313909-075548f0-a58c-40b8-8166-46d59389d74a.gif)

New Behaviour:
![Snap-Through-Floor-Fixed](https://user-images.githubusercontent.com/3240136/215313914-540e26c5-4459-4edd-9688-30fd1c973cff.gif)

# How Has This Been Tested?

Wrote an automated unit test `Verify_KCCMovementEngine_NoMoveIntoGround` to ensure that the player will no longer snap into the ground when computing the new position relative to the parent.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that demonstrate the new feature or bugfix
- [x] New and existing unit and integrations tests pass locally with my changes
