### PR TITLE
Jittery Stairs Camera

### DIFF
--- a/Assets/Samples/CinemachineExample/CinemachineExample.unity
+++ b/Assets/Samples/CinemachineExample/CinemachineExample.unity
@@ -468,6 +468,37 @@ MonoBehaviour:
   m_SelectedFaces: 
   m_SelectedEdges: []
   m_SelectedVertices: 
+--- !u!1 &93225601
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 93225602}
+  m_Layer: 0
+  m_Name: Spawn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &93225602
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 93225601}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &218928797
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1891,7 +1922,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1431890374}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.5, y: 2.4, z: -2}
+  m_LocalPosition: {x: 6.5, y: 1.401, z: -3}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -5862,6 +5893,65 @@ MonoBehaviour:
     m_LegacyHeadingDefinition: -1
     m_LegacyVelocityFilterStrength: -1
   m_ApplyBeforeBody: 0
+--- !u!1 &1873045172
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1873045174}
+  - component: {fileID: 1873045173}
+  - component: {fileID: 1873045175}
+  m_Layer: 0
+  m_Name: Teleport Box
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &1873045173
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1873045172}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1000, y: 100, z: 1000}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!4 &1873045174
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1873045172}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -200, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1873045175
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1873045172}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d7d1ea531b8a338468e3d314beea4a5c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  teleportLocation: {fileID: 93225602}
 --- !u!1001 &3750379031515595089
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Samples/CinemachineExample/CinemachineExample.unity
+++ b/Assets/Samples/CinemachineExample/CinemachineExample.unity
@@ -600,25 +600,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2196a8cb2ba6240408e06ee5f8007dc4, type: 3}
---- !u!1 &430482176 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 3372921313112048414, guid: 6e70b95889762554594e5a920d954870, type: 3}
-  m_PrefabInstance: {fileID: 3750379031515595089}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &430482188
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 430482176}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 15f66b88142720c4aae6d185c2eef28c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  avatarBase: {fileID: 1144863067}
-  smooth: 0.1
 --- !u!43 &631413356
 Mesh:
   m_ObjectHideFlags: 0
@@ -1528,7 +1509,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1121763820}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 6, y: 1.401, z: -8}
+  m_LocalPosition: {x: 6.5, y: 1.401, z: -3}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1602,11 +1583,6 @@ MonoBehaviour:
   m_CameraActivatedEvent:
     m_PersistentCalls:
       m_Calls: []
---- !u!1 &1144863067 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 2454021725001223283, guid: 6e70b95889762554594e5a920d954870, type: 3}
-  m_PrefabInstance: {fileID: 3750379031515595089}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1267049604
 GameObject:
   m_ObjectHideFlags: 0
@@ -5959,14 +5935,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 3372921311804508139, guid: 6e70b95889762554594e5a920d954870, type: 3}
-      propertyPath: sprintSpeed
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 3372921311804508139, guid: 6e70b95889762554594e5a920d954870, type: 3}
-      propertyPath: walkingSpeed
-      value: 4
-      objectReference: {fileID: 0}
     - target: {fileID: 3372921313112048409, guid: 6e70b95889762554594e5a920d954870, type: 3}
       propertyPath: m_RootOrder
       value: 3

--- a/Assets/Samples/CinemachineExample/CinemachineExample.unity
+++ b/Assets/Samples/CinemachineExample/CinemachineExample.unity
@@ -569,6 +569,25 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2196a8cb2ba6240408e06ee5f8007dc4, type: 3}
+--- !u!1 &430482176 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3372921313112048414, guid: 6e70b95889762554594e5a920d954870, type: 3}
+  m_PrefabInstance: {fileID: 3750379031515595089}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &430482188
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 430482176}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 15f66b88142720c4aae6d185c2eef28c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  avatarBase: {fileID: 1144863067}
+  smooth: 0.1
 --- !u!43 &631413356
 Mesh:
   m_ObjectHideFlags: 0
@@ -796,7 +815,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 846941005}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 4, y: 0, z: -2}
+  m_LocalPosition: {x: 4, y: 0, z: -6}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1478,7 +1497,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1121763820}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1.4, z: -4}
+  m_LocalPosition: {x: 6, y: 1.401, z: -8}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1552,6 +1571,11 @@ MonoBehaviour:
   m_CameraActivatedEvent:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &1144863067 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2454021725001223283, guid: 6e70b95889762554594e5a920d954870, type: 3}
+  m_PrefabInstance: {fileID: 3750379031515595089}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1267049604
 GameObject:
   m_ObjectHideFlags: 0
@@ -1616,7 +1640,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1267049604}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 2.4, z: 0}
+  m_LocalPosition: {x: 6, y: 1.401, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1646,7 +1670,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh117934
+  m_Name: pb_Mesh42402
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -1932,11 +1956,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bd6043bde05a7fc4cba197d06915c1e3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Damping: {x: 0.1, y: 0.5, z: 0.3}
+  Damping: {x: 0.1, y: 0.8, z: 0.3}
   ShoulderOffset: {x: 0.5, y: -0.4, z: 0}
   VerticalArmLength: 0.4
   CameraSide: 1
-  CameraDistance: 2
+  CameraDistance: 3
   CameraCollisionFilter:
     serializedVersion: 2
     m_Bits: 2147483647
@@ -5410,7 +5434,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh117912
+  m_Name: pb_Mesh42380
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -5633,7 +5657,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1728522682}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 1.4, z: -4}
+  m_LocalPosition: {x: 6, y: 1.401, z: -8}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -5743,9 +5767,9 @@ MonoBehaviour:
   m_TargetMovementOnly: 1
   m_ScreenX: 0.5
   m_ScreenY: 0.5
-  m_CameraDistance: 4
+  m_CameraDistance: 8
   m_DeadZoneWidth: 0.1
-  m_DeadZoneHeight: 0.1
+  m_DeadZoneHeight: 0.6
   m_DeadZoneDepth: 0
   m_UnlimitedSoftZone: 0
   m_SoftZoneWidth: 0.8
@@ -5845,17 +5869,25 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 3372921311804508139, guid: 6e70b95889762554594e5a920d954870, type: 3}
+      propertyPath: sprintSpeed
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3372921311804508139, guid: 6e70b95889762554594e5a920d954870, type: 3}
+      propertyPath: walkingSpeed
+      value: 4
+      objectReference: {fileID: 0}
     - target: {fileID: 3372921313112048409, guid: 6e70b95889762554594e5a920d954870, type: 3}
       propertyPath: m_RootOrder
       value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3372921313112048409, guid: 6e70b95889762554594e5a920d954870, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 3372921313112048409, guid: 6e70b95889762554594e5a920d954870, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 0.001
       objectReference: {fileID: 0}
     - target: {fileID: 3372921313112048409, guid: 6e70b95889762554594e5a920d954870, type: 3}
       propertyPath: m_LocalPosition.z

--- a/Assets/Samples/CinemachineExample/CinemachinePlayer.prefab
+++ b/Assets/Samples/CinemachineExample/CinemachinePlayer.prefab
@@ -50,6 +50,7 @@ GameObject:
   - component: {fileID: 1928389238171943504}
   - component: {fileID: 1928389238171943512}
   - component: {fileID: 1928389238171943513}
+  - component: {fileID: 430482188}
   m_Layer: 0
   m_Name: CinemachinePlayer
   m_TagString: Player
@@ -230,8 +231,8 @@ MonoBehaviour:
   moveActionReference: {fileID: 8130185064591157487, guid: 59c551f8259784a429773ca4a275eb03, type: 3}
   sprintActionReference: {fileID: -6424176782126915535, guid: 59c551f8259784a429773ca4a275eb03, type: 3}
   jumpActionReference: {fileID: 1481124759659193975, guid: 59c551f8259784a429773ca4a275eb03, type: 3}
-  walkingSpeed: 6.5
-  sprintSpeed: 8.5
+  walkingSpeed: 4
+  sprintSpeed: 6
   jumpVelocity: 6.5
 --- !u!114 &3195248330151296820
 MonoBehaviour:
@@ -307,6 +308,20 @@ MonoBehaviour:
   fadeThreshold: 0.5
   shadowOnlyDistance: 0.25
   cameraRadius: 0.1
+--- !u!114 &430482188
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3372921313112048414}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 15f66b88142720c4aae6d185c2eef28c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  avatarBase: {fileID: 2454021725001223283}
+  smooth: 0.1
 --- !u!1001 &3372921312279736610
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Packages/com.nickmaltbie.openkcc.cinemachine/CHANGELOG.md
+++ b/Packages/com.nickmaltbie.openkcc.cinemachine/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## In Progress
 
+* Added basic `SmoothAvatarPos` to smooth avatar position based on some damping
+    factor to smooth out any jittery movements of the player when snapping
+    up or down surfaces.
 * Added basic test scene and scripts for different camera perspectives including:
     * Over the shoulder camera
     * Third person re-centering camera

--- a/Packages/com.nickmaltbie.openkcc.cinemachine/OpenKCC.cinemachine/Player/SmoothAvatarPos.cs
+++ b/Packages/com.nickmaltbie.openkcc.cinemachine/OpenKCC.cinemachine/Player/SmoothAvatarPos.cs
@@ -1,0 +1,53 @@
+// Copyright (C) 2023 Nicholas Maltbie
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using nickmaltbie.OpenKCC.Utils;
+using nickmaltbie.TestUtilsUnity;
+using UnityEngine;
+
+namespace nickmaltbie.OpenKCC.cinemachine.Player
+{
+    public class SmoothAvatarPos : MonoBehaviour
+    {
+        /// <summary>
+        /// Unity service for managing testing.
+        /// </summary>
+        public IUnityService unityService = UnityService.Instance;
+
+        /// <summary>
+        /// Avatar base to rotate.
+        /// </summary>
+        public GameObject avatarBase;
+
+        public float smooth = 0.05f;
+        private Vector3 offset;
+        private Vector3 previousPos;
+
+        public void Awake()
+        {
+            previousPos = transform.position;
+            offset = avatarBase.transform.position - transform.position;
+        }
+
+        public void FixedUpdate()
+        {
+            previousPos = Vector3.Lerp(transform.position, previousPos, smooth);
+            avatarBase.transform.position = previousPos + offset;
+        }
+    }
+}

--- a/Packages/com.nickmaltbie.openkcc.cinemachine/OpenKCC.cinemachine/Player/SmoothAvatarPos.cs
+++ b/Packages/com.nickmaltbie.openkcc.cinemachine/OpenKCC.cinemachine/Player/SmoothAvatarPos.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Nicholas Maltbie
+﻿// Copyright (C) 2023 Nicholas Maltbie
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -17,7 +17,6 @@
 // SOFTWARE.
 
 using nickmaltbie.OpenKCC.Character;
-using nickmaltbie.OpenKCC.Utils;
 using nickmaltbie.TestUtilsUnity;
 using UnityEngine;
 
@@ -38,7 +37,7 @@ namespace nickmaltbie.OpenKCC.cinemachine.Player
         /// <summary>
         /// Factor to smooth player position by.
         /// </summary>
-        [Range(0.0f, 0.1f)]
+        [Range(0.0f, 1.0f)]
         public float smooth = 0.05f;
 
         /// <summary>

--- a/Packages/com.nickmaltbie.openkcc.cinemachine/OpenKCC.cinemachine/Player/SmoothAvatarPos.cs
+++ b/Packages/com.nickmaltbie.openkcc.cinemachine/OpenKCC.cinemachine/Player/SmoothAvatarPos.cs
@@ -16,13 +16,14 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using nickmaltbie.OpenKCC.Character;
 using nickmaltbie.OpenKCC.Utils;
 using nickmaltbie.TestUtilsUnity;
 using UnityEngine;
 
 namespace nickmaltbie.OpenKCC.cinemachine.Player
 {
-    public class SmoothAvatarPos : MonoBehaviour
+    public class SmoothAvatarPos : MonoBehaviour, IOnPlayerTeleport
     {
         /// <summary>
         /// Unity service for managing testing.
@@ -34,8 +35,20 @@ namespace nickmaltbie.OpenKCC.cinemachine.Player
         /// </summary>
         public GameObject avatarBase;
 
+        /// <summary>
+        /// Factor to smooth player position by.
+        /// </summary>
+        [Range(0.0f, 0.1f)]
         public float smooth = 0.05f;
+
+        /// <summary>
+        /// Saved offset of avatar from current position.
+        /// </summary>
         private Vector3 offset;
+
+        /// <summary>
+        /// Previous position of player.
+        /// </summary>
         private Vector3 previousPos;
 
         public void Awake()
@@ -48,6 +61,11 @@ namespace nickmaltbie.OpenKCC.cinemachine.Player
         {
             previousPos = Vector3.Lerp(transform.position, previousPos, smooth);
             avatarBase.transform.position = previousPos + offset;
+        }
+
+        public void OnPlayerTeleport(Vector3 destPos, Quaternion destRot)
+        {
+            previousPos = destPos;
         }
     }
 }

--- a/Packages/com.nickmaltbie.openkcc.cinemachine/OpenKCC.cinemachine/Player/SmoothAvatarPos.cs.meta
+++ b/Packages/com.nickmaltbie.openkcc.cinemachine/OpenKCC.cinemachine/Player/SmoothAvatarPos.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 15f66b88142720c4aae6d185c2eef28c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.nickmaltbie.openkcc.cinemachine/Tests/EditMode/Player/SmoothAvatarPosTests.cs
+++ b/Packages/com.nickmaltbie.openkcc.cinemachine/Tests/EditMode/Player/SmoothAvatarPosTests.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Nicholas Maltbie
+﻿// Copyright (C) 2023 Nicholas Maltbie
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -16,7 +16,6 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
 using Moq;
 using nickmaltbie.OpenKCC.cinemachine.Player;
 using nickmaltbie.OpenKCC.Utils;
@@ -24,7 +23,6 @@ using nickmaltbie.TestUtilsUnity;
 using nickmaltbie.TestUtilsUnity.Tests.TestCommon;
 using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.TestTools;
 
 namespace nickmaltbie.OpenKCC.Tests.cinemachine.EditMode.Player
 {
@@ -43,7 +41,7 @@ namespace nickmaltbie.OpenKCC.Tests.cinemachine.EditMode.Player
             smooth.avatarBase = avatar;
             smooth.smooth = smoothFactor;
 
-            Mock<IUnityService> unityServiceMock = new Mock<IUnityService>();
+            var unityServiceMock = new Mock<IUnityService>();
             unityServiceMock.Setup(e => e.deltaTime).Returns(1.0f);
             smooth.unityService = unityServiceMock.Object;
 

--- a/Packages/com.nickmaltbie.openkcc.cinemachine/Tests/EditMode/Player/SmoothAvatarPosTests.cs
+++ b/Packages/com.nickmaltbie.openkcc.cinemachine/Tests/EditMode/Player/SmoothAvatarPosTests.cs
@@ -1,0 +1,76 @@
+// Copyright (C) 2023 Nicholas Maltbie
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections;
+using Moq;
+using nickmaltbie.OpenKCC.cinemachine.Player;
+using nickmaltbie.OpenKCC.Utils;
+using nickmaltbie.TestUtilsUnity;
+using nickmaltbie.TestUtilsUnity.Tests.TestCommon;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace nickmaltbie.OpenKCC.Tests.cinemachine.EditMode.Player
+{
+    [TestFixture]
+    public class SmoothAvatarPosTests : TestBase
+    {
+        [Test]
+        public void Verify_SmoothAvatarPos([NUnit.Framework.Range(0, 0.8f, 0.1f)] float smoothFactor)
+        {
+            GameObject avatar = CreateGameObject();
+            GameObject parent = CreateGameObject();
+
+            avatar.transform.SetParent(parent.transform);
+
+            SmoothAvatarPos smooth = parent.AddComponent<SmoothAvatarPos>();
+            smooth.avatarBase = avatar;
+            smooth.smooth = smoothFactor;
+
+            Mock<IUnityService> unityServiceMock = new Mock<IUnityService>();
+            unityServiceMock.Setup(e => e.deltaTime).Returns(1.0f);
+            smooth.unityService = unityServiceMock.Object;
+
+            smooth.Awake();
+            smooth.FixedUpdate();
+
+            // Assert that as the player moves, it is smoothed between
+            // the previous position and the destination position
+            Vector3 previous = parent.transform.position;
+            parent.transform.position += Vector3.forward;
+            Vector3 destination = parent.transform.position;
+
+            smooth.FixedUpdate();
+            int maxUpdate = 1000;
+            int update = 0;
+            while (Vector3.Distance(avatar.transform.position, parent.transform.position) > KCCUtils.Epsilon)
+            {
+                smooth.FixedUpdate();
+
+                // Assert that the player is between the initial and final pos
+                Vector3 deltaStart = avatar.transform.position - previous;
+                Vector3 deltaEnd = destination - avatar.transform.position;
+                TestUtils.AssertInBounds(deltaStart + deltaEnd, Vector3.forward, 0.01f);
+
+                update++;
+                Assert.IsTrue(update <= maxUpdate);
+            }
+        }
+    }
+}

--- a/Packages/com.nickmaltbie.openkcc.cinemachine/Tests/EditMode/Player/SmoothAvatarPosTests.cs.meta
+++ b/Packages/com.nickmaltbie.openkcc.cinemachine/Tests/EditMode/Player/SmoothAvatarPosTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c0a9fbf6c3eacf74f80b1d5a34336617
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.nickmaltbie.openkcc/CHANGELOG.md
+++ b/Packages/com.nickmaltbie.openkcc/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 * Adjusted how stairs and snap down are handled in `KCCMovementEngine`
     and `KCCUtils` to make player slowly move up or down stairs based on
     the remaining movement speed of the player.
+* Adjusted `KCCMovementEngine` to have a max speed for snapping down
+    to stop the player from teleporting down harshly and making player camera
+    jitter.
 * Added `IOnPlayerTeleport` to listen to teleport events from
     the `KCCMovementEngine` and respond accordingly.
 

--- a/Packages/com.nickmaltbie.openkcc/CHANGELOG.md
+++ b/Packages/com.nickmaltbie.openkcc/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## In Progress
 
+* Adjusted how stairs and snap down are handled in `KCCMovementEngine`
+    and `KCCUtils` to make player slowly move up or down stairs based on
+    the remaining movement speed of the player.
+* Added `IOnPlayerTeleport` to listen to teleport events from
+    the `KCCMovementEngine` and respond accordingly.
+
 ## [1.3.0] 2023-1-29
 
 _**Note**_ : This update will not automatically

--- a/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/IOnPlayerTeleport.cs
+++ b/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/IOnPlayerTeleport.cs
@@ -1,0 +1,48 @@
+// Copyright (C) 2023 Nicholas Maltbie
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using nickmaltbie.OpenKCC.CameraControls;
+using nickmaltbie.OpenKCC.Character.Action;
+using nickmaltbie.OpenKCC.Character.Attributes;
+using nickmaltbie.OpenKCC.Character.Config;
+using nickmaltbie.OpenKCC.Character.Events;
+using nickmaltbie.OpenKCC.Utils;
+using nickmaltbie.StateMachineUnity;
+using nickmaltbie.StateMachineUnity.Attributes;
+using nickmaltbie.StateMachineUnity.Event;
+using nickmaltbie.StateMachineUnity.Fixed;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using static nickmaltbie.OpenKCC.Character.Animation.HumanoidKCCAnim;
+
+namespace nickmaltbie.OpenKCC.Character
+{
+    /// <summary>
+    /// Listen for player teleport events and do something when
+    /// the player is teleported.
+    /// </summary>
+    public interface IOnPlayerTeleport
+    {
+        /// <summary>
+        /// When a player is teleported to a given location.
+        /// </summary>
+        /// <param name="destPos">Position being teleported to.</param>
+        /// <param name="destRot">Rotation being teleported to.</param>
+        void OnPlayerTeleport(Vector3 destPos, Quaternion destRot);
+    }
+}

--- a/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/IOnPlayerTeleport.cs
+++ b/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/IOnPlayerTeleport.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 Nicholas Maltbie
+﻿// Copyright (C) 2023 Nicholas Maltbie
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 // associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -16,19 +16,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using nickmaltbie.OpenKCC.CameraControls;
-using nickmaltbie.OpenKCC.Character.Action;
-using nickmaltbie.OpenKCC.Character.Attributes;
-using nickmaltbie.OpenKCC.Character.Config;
-using nickmaltbie.OpenKCC.Character.Events;
-using nickmaltbie.OpenKCC.Utils;
-using nickmaltbie.StateMachineUnity;
-using nickmaltbie.StateMachineUnity.Attributes;
-using nickmaltbie.StateMachineUnity.Event;
-using nickmaltbie.StateMachineUnity.Fixed;
 using UnityEngine;
-using UnityEngine.InputSystem;
-using static nickmaltbie.OpenKCC.Character.Animation.HumanoidKCCAnim;
 
 namespace nickmaltbie.OpenKCC.Character
 {

--- a/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/IOnPlayerTeleport.cs.meta
+++ b/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/IOnPlayerTeleport.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c34c974f7eef944e8c056c106eb0ad5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/KCCMovementEngine.cs
+++ b/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/KCCMovementEngine.cs
@@ -312,6 +312,7 @@ namespace nickmaltbie.OpenKCC.Character
                 snappedDown = true;
                 SnapPlayerDown();
             }
+
             CheckGrounded(snappedUp || snappedDown);
 
             Vector3 delta = transform.position - start;
@@ -375,7 +376,7 @@ namespace nickmaltbie.OpenKCC.Character
                     -Up,
                     SnapDown,
                     ColliderCast);
-                
+
                 groundCheckPos += snapDelta;
             }
 

--- a/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/KCCMovementEngine.cs
+++ b/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/KCCMovementEngine.cs
@@ -156,7 +156,7 @@ namespace nickmaltbie.OpenKCC.Character
         /// <summary>
         /// Relative parent configuration for following the ground.
         /// </summary>
-        internal RelativeParentConfig relativeParentConfig;
+        public RelativeParentConfig RelativeParentConfig { get; protected set; }
 
         /// <summary>
         /// Current grounded state of the character.
@@ -270,7 +270,7 @@ namespace nickmaltbie.OpenKCC.Character
         /// </summary>
         public void Update()
         {
-            relativeParentConfig.FollowGround(transform);
+            RelativeParentConfig.FollowGround(transform);
         }
 
         /// <summary>
@@ -281,7 +281,7 @@ namespace nickmaltbie.OpenKCC.Character
         /// <param name="moves">Desired player movement in world space.</param>
         public virtual KCCBounce[] MovePlayer(params Vector3[] moves)
         {
-            relativeParentConfig.FollowGround(transform);
+            RelativeParentConfig.FollowGround(transform);
             Vector3 previousVelocity = (transform.position - previousPosition) / unityService.deltaTime;
             worldVelocity.AddSample(previousVelocity);
 
@@ -315,8 +315,8 @@ namespace nickmaltbie.OpenKCC.Character
             CheckGrounded(snappedUp || snappedDown);
 
             Vector3 delta = transform.position - start;
-            transform.position += relativeParentConfig.UpdateMovingGround(start, GroundedState, delta, unityService.fixedDeltaTime);
-            relativeParentConfig.FollowGround(transform);
+            transform.position += RelativeParentConfig.UpdateMovingGround(start, GroundedState, delta, unityService.fixedDeltaTime);
+            RelativeParentConfig.FollowGround(transform);
 
             previousPosition = transform.position;
             return bounces;
@@ -328,8 +328,13 @@ namespace nickmaltbie.OpenKCC.Character
         /// <param name="position">Position to teleport player to.</param>
         public void TeleportPlayer(Vector3 position)
         {
-            relativeParentConfig.Reset();
+            RelativeParentConfig.Reset();
             transform.position = position;
+
+            foreach (IOnPlayerTeleport tele in GetComponents<IOnPlayerTeleport>())
+            {
+                tele.OnPlayerTeleport(position, transform.rotation);
+            }
         }
 
         /// <summary>

--- a/Packages/com.nickmaltbie.openkcc/OpenKCC/Utils/KCCUtils.cs
+++ b/Packages/com.nickmaltbie.openkcc/OpenKCC/Utils/KCCUtils.cs
@@ -201,7 +201,7 @@ namespace nickmaltbie.OpenKCC.Utils
                     momentum.normalized,
                     momentum.magnitude,
                     out IRaycastHit forwardHit);
-                
+
                 float forwardDist = didForwardHit ? Mathf.Max(0, forwardHit.distance - KCCUtils.Epsilon) : momentum.magnitude;
                 position += forwardDist * momentum.normalized;
                 momentum = momentum.normalized * remainingMomentum;

--- a/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Character/KCCMovementEngineTests.cs
+++ b/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Character/KCCMovementEngineTests.cs
@@ -27,6 +27,16 @@ using UnityEngine;
 
 namespace nickmaltbie.OpenKCC.Tests.EditMode.Character
 {
+    public class VerifyTeleport : MonoBehaviour, IOnPlayerTeleport
+    {
+        public Vector3 teleportPos = Vector3.zero;
+
+        public void OnPlayerTeleport(Vector3 destPos, Quaternion destRot)
+        {
+            teleportPos = destPos;   
+        }
+    }
+
     /// <summary>
     /// Basic tests for <see cref="nickmaltbie.OpenKCC.Character.KCCMovementEngine"/> in edit mode.
     /// </summary>
@@ -42,6 +52,14 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode.Character
             engine = CreateGameObject().AddComponent<KCCMovementEngine>();
             colliderCastMock = new Mock<IColliderCast>();
             engine._colliderCast = colliderCastMock.Object;
+        }
+
+        [Test]
+        public void Verify_KCCMovementEngine_OnPlayerTeleport([NUnit.Framework.Range(0, 100, 10)] float dist)
+        {
+            VerifyTeleport verify = engine.gameObject.AddComponent<VerifyTeleport>();
+            engine.TeleportPlayer(Vector3.forward * dist);
+            Assert.AreEqual(verify.teleportPos, Vector3.forward * dist);
         }
 
         [Test]
@@ -265,16 +283,13 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode.Character
             // one meter below the player.
             engine.MovePlayer(Vector3.down);
 
-            // Now assert that the relative position of the player
-            // to the ground is roughly 0.5 units above and that the
-            // absolute position of the player is about (0, 0.5, 0)
+            // Now assert that the absolute position of the player
+            // is about (0, 0.5, 0)
             TestUtils.AssertInBounds(engine.transform.position, Vector3.up * 0.5f, 2 * KCCUtils.Epsilon);
-            TestUtils.AssertInBounds(engine.relativeParentConfig.relativePos, Vector3.up, 2 * KCCUtils.Epsilon);
 
             // After calling Update this should be true as well.
             engine.Update();
             TestUtils.AssertInBounds(engine.transform.position, Vector3.up * 0.5f, 2 * KCCUtils.Epsilon);
-            TestUtils.AssertInBounds(engine.relativeParentConfig.relativePos, Vector3.up, 2 * KCCUtils.Epsilon);
         }
     }
 }

--- a/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Character/KCCMovementEngineTests.cs
+++ b/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Character/KCCMovementEngineTests.cs
@@ -33,7 +33,7 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode.Character
 
         public void OnPlayerTeleport(Vector3 destPos, Quaternion destRot)
         {
-            teleportPos = destPos;   
+            teleportPos = destPos;
         }
     }
 

--- a/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Utils/KCCUtilsTests.cs
+++ b/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Utils/KCCUtilsTests.cs
@@ -207,7 +207,7 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode.Utils
             colliderCastMock.Setup(mock => mock.GetBottom(It.IsAny<Vector3>(), It.IsAny<Quaternion>())).Returns(Vector3.zero);
 
             // Simulate bounces
-            var bounces = GetBounces(Vector3.zero, Vector3.forward, verticalSnapUp: snapUpDistance).ToList();
+            var bounces = GetBounces(Vector3.zero, Vector3.forward * 10, verticalSnapUp: snapUpDistance).ToList();
 
             // Validate bounce properties
             Assert.IsTrue(bounces.Count == 3, $"Expected to find {3} bounce but instead found {bounces.Count}");


### PR DESCRIPTION
# Description

* Adjusted how stairs and snap down are handled in `KCCMovementEngine` and `KCCUtils` to make player slowly move up or down stairs based on the remaining movement speed of the player.
* Adjusted `KCCMovementEngine` to have a max speed for snapping down to stop the player from teleporting down harshly and making player camera jitter.
* Added `IOnPlayerTeleport` to listen to teleport events from the `KCCMovementEngine` and respond accordingly.
* Added basic `SmoothAvatarPos` to smooth avatar position based on some damping factor to smooth out any jittery movements of the player when snapping up or down surfaces.

# How Has This Been Tested?

Created and updated automated tests to verify no expected behaviors are broken.
Used the smooth factor to verify that the player is no longer jittery when walking up/down stairs.

https://user-images.githubusercontent.com/3240136/218521705-103f4606-ae8d-4c9b-aa89-3e2b45794ff4.mp4

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that demonstrate the new feature or bugfix
- [x] New and existing unit and integrations tests pass locally with my changes
