### PR TITLE
Stair Movement Normals

### DIFF
--- a/Assets/Samples/MoleKCCSample/Scripts/MoleCharacter.cs
+++ b/Assets/Samples/MoleKCCSample/Scripts/MoleCharacter.cs
@@ -351,7 +351,7 @@ namespace nickmaltbie.OpenKCC.MoleKCCSample
             if (!IsOwner)
             {
                 // movementEngine.SetNormal(relativeUp.Value);
-                movementEngine.CheckGrounded(false);
+                movementEngine.CheckGrounded(false, false);
             }
 
             bool particlesEnabled = Attribute.GetCustomAttribute(CurrentState, typeof(DiggingParticlesEnabled)) != null;

--- a/Assets/Samples/MoleKCCSample/Scripts/MoleMovementEngine.cs
+++ b/Assets/Samples/MoleKCCSample/Scripts/MoleMovementEngine.cs
@@ -103,7 +103,7 @@ namespace nickmaltbie.OpenKCC.MoleKCCSample
             }
 
             // Compute the new grounded state
-            CheckGrounded(false);
+            CheckGrounded(false, false);
             GroundNormal = GroundedState.SurfaceNormal;
 
             if (GroundNormal == Vector3.zero)

--- a/Packages/com.nickmaltbie.openkcc/CHANGELOG.md
+++ b/Packages/com.nickmaltbie.openkcc/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## In Progress
 
+* Addressing small bug in player movement caused by stair movement normals
+    not being computed properly when walking down stairs.
+
 ## [1.3.4] 2023-04-01
 
 * Refactored common assets (like UI) to `ExampleFirstPersonKCC` sample 

--- a/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Character/Config/KCCGroundedStateTests.cs
+++ b/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Character/Config/KCCGroundedStateTests.cs
@@ -25,7 +25,7 @@ using nickmaltbie.TestUtilsUnity.Tests.TestCommon;
 using NUnit.Framework;
 using UnityEngine;
 
-namespace nickmaltbie.OpenKCC.Tests.EditMode.Character.Action
+namespace nickmaltbie.OpenKCC.Tests.EditMode.Character.Config
 {
     /// <summary>
     /// Basic tests for <see cref="nickmaltbie.OpenKCC.Character.Config.KCCGroundedState"/> in edit mode.
@@ -51,10 +51,11 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode.Character.Action
         public void Validate_KCCGroundedState_CheckGrounded_StandingOnGround()
         {
             KCCTestUtils.SetupCastSelf(colliderCastMock, normal: Vector3.up, distance: 0.001f, didHit: true);
-            kccGroundedState = movementEngine.CheckGrounded(false);
+            kccGroundedState = movementEngine.CheckGrounded(false, false);
 
             TestUtils.AssertInBounds(kccGroundedState.Angle, 0.0f);
             Assert.IsTrue(kccGroundedState.StandingOnGround);
+            Assert.IsTrue(kccGroundedState.StandingOnGroundOrOverlap);
             Assert.IsTrue(kccGroundedState.DistanceToGround == 0.001f);
             Assert.IsFalse(kccGroundedState.Sliding);
         }
@@ -65,7 +66,7 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode.Character.Action
         )
         {
             KCCTestUtils.SetupCastSelf(colliderCastMock, normal: Vector3.up, distance: distance, didHit: distance < Mathf.Infinity);
-            kccGroundedState = movementEngine.CheckGrounded(false);
+            kccGroundedState = movementEngine.CheckGrounded(false, false);
 
             Assert.IsFalse(kccGroundedState.StandingOnGround);
             Assert.IsFalse(kccGroundedState.Sliding);
@@ -78,7 +79,7 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode.Character.Action
             [Values] bool falling)
         {
             KCCTestUtils.SetupCastSelf(colliderCastMock, normal: Vector3.up, distance: 0.001f, didHit: falling);
-            kccGroundedState = movementEngine.CheckGrounded(false);
+            kccGroundedState = movementEngine.CheckGrounded(false, false);
 
             if (falling)
             {
@@ -96,7 +97,7 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode.Character.Action
         public void Validate_KCCGroundedState_CheckGrounded_Sliding()
         {
             KCCTestUtils.SetupCastSelf(colliderCastMock, distance: 0.001f, normal: (Vector3.up + Vector3.right * 10).normalized, didHit: true);
-            kccGroundedState = movementEngine.CheckGrounded(false);
+            kccGroundedState = movementEngine.CheckGrounded(false, false);
 
             Assert.IsTrue(kccGroundedState.StandingOnGround);
             Assert.IsTrue(kccGroundedState.Sliding);

--- a/Packages/com.nickmaltbie.openkcc/Tests/TestCommon/KCCTestUtils.cs
+++ b/Packages/com.nickmaltbie.openkcc/Tests/TestCommon/KCCTestUtils.cs
@@ -28,6 +28,30 @@ namespace nickmaltbie.OpenKCC.Tests.TestCommon
     public static class KCCTestUtils
     {
         /// <summary>
+        /// Callback function for <see cref="nickmaltbie.OpenKCC.Utils.IColliderCast.DoRaycastInDirection"/>
+        /// </summary>
+        /// <param name="source">Source point to check from.</param>
+        /// <param name="direction">Direction to search for step.</param>
+        /// <param name="distance">Distance to search for step ahead of player.</param>
+        /// <param name="hit">Information about hit.</param>
+        /// <param name="layerMask">Layer mask for checking which objects to collide with.</param>
+        /// <param name="queryTriggerInteraction">Configuration for QueryTriggerInteraction when solving for collisions.</param>
+        /// <returns>Is something ahead hit.</returns>
+        public delegate void DoRaycastInDirectionCallback(Vector3 source, Vector3 direction, float distance, out IRaycastHit hit, int layerMask, QueryTriggerInteraction queryTriggerInteraction);
+
+        /// <summary>
+        /// Callback function for <see cref="nickmaltbie.OpenKCC.Utils.IColliderCast.DoRaycastInDirection"/>
+        /// </summary>
+        /// <param name="source">Source point to check from.</param>
+        /// <param name="direction">Direction to search for step.</param>
+        /// <param name="distance">Distance to search for step ahead of player.</param>
+        /// <param name="hit">Information about hit.</param>
+        /// <param name="layerMask">Layer mask for checking which objects to collide with.</param>
+        /// <param name="queryTriggerInteraction">Configuration for QueryTriggerInteraction when solving for collisions.</param>
+        /// <returns>Is something ahead hit.</returns>
+        public delegate bool DoRaycastInDirectionReturns(Vector3 source, Vector3 direction, float distance, out IRaycastHit hit, int layerMask, QueryTriggerInteraction queryTriggerInteraction);
+
+        /// <summary>
         /// Callback function for <see cref="nickmaltbie.OpenKCC.Utils.IColliderCast.CastSelf"/>
         /// </summary>
         /// <param name="position">Position of the object when it is being raycast.</param>


### PR DESCRIPTION
# Description

Addressing one of the action items in Issue #194 
> Create smaller PR for patching ground normal detection when walking down steps

The player quickly transitioning to the falling animation when stepping down making them look like they are bouncing. this is caused by the player normal vector not being computed properly when walking down stairs. The normal vector is being computed as the angle between the collider and the point of contact with the ground. But when walking down steps, this should instead be computed via the step the player is trying to stand on. We can calculate this by drawing a second ray down when computing the grounded angle. I included a small diagram showing what this looks like with two rows below.
The first row has a red vector showing the desired normal, and a blue vector showing the computed normal, the second row shows the desired behavior with a red vector showing the desired normal, and a green vector showing the newly computed normal.

![image](https://github.com/nicholas-maltbie/OpenKCC/assets/3240136/7a8e1d13-063d-46a8-8f35-2f7863294c3b)

I actually already follow this behavior for walking up steps which is why the falling animation bug doesn't happen as often while walking up steps.

Thanks for pointing out the issue @Conserp when this passes the merge PRs, I'll merge it into the project, but if you have any questions or follow up for the code changes feel free to let me know. This is just addressing one of the action items. The other ones will be addressed as part of either Issue #195 or in future PRs :)
