### PR TITLE
Adjusting Flaky PlayMode tests

### DIFF
--- a/Packages/com.nickmaltbie.openkcc.netcode/OpenKCC.netcode/Character/NetworkKCC.cs
+++ b/Packages/com.nickmaltbie.openkcc.netcode/OpenKCC.netcode/Character/NetworkKCC.cs
@@ -184,6 +184,7 @@ namespace nickmaltbie.OpenKCC.netcode.Character
 
         [Animation(LandingAnimState, 0.1f, true)]
         [TransitionOnAnimationComplete(typeof(IdleState), 0.25f, true)]
+        [TransitionAfterTime(typeof(IdleState), 1.0f)]
         [AnimationTransition(typeof(StartMoveInput), typeof(WalkingState), 0.35f, true)]
         [AnimationTransition(typeof(JumpEvent), typeof(JumpState), 0.35f, true)]
         [Transition(typeof(LeaveGroundEvent), typeof(FallingState))]

--- a/Packages/com.nickmaltbie.openkcc.netcode/Tests/Runtime/Character/NetworkKCCTests.cs
+++ b/Packages/com.nickmaltbie.openkcc.netcode/Tests/Runtime/Character/NetworkKCCTests.cs
@@ -19,6 +19,7 @@
 using System.Collections;
 using System.Linq;
 using nickmaltbie.openkcc.Tests.netcode.TestCommon;
+using nickmaltbie.OpenKCC.Character;
 using nickmaltbie.OpenKCC.Character.Action;
 using nickmaltbie.OpenKCC.Character.Animation;
 using nickmaltbie.OpenKCC.Environment.MovingGround;
@@ -185,9 +186,14 @@ namespace nickmaltbie.openkcc.Tests.netcode.Runtime.Character
             SetupPlayersInIdleState();
             floor.transform.position = Vector3.down * 3;
             yield return new WaitForFixedUpdate();
-            floor.transform.rotation = Quaternion.Euler(70.0f, 0, 0);
+            floor.transform.rotation = Quaternion.Euler(10, 0, 0);
 
-            ForEachOwner((player, i) => player.TeleportPlayer(Vector3.up));
+            // Adjust each player's max walk angle to 5 degrees
+            ForAllPlayers(player =>
+            {
+                player.GetComponent<KCCMovementEngine>().maxWalkAngle = 5;
+                return true;
+            });
 
             // Wait until players are in sliding satte
             yield return TestUtils.WaitUntil(() => ForAllPlayers(player => typeof(SlidingState) == player.CurrentState));

--- a/Packages/com.nickmaltbie.openkcc.netcode/Tests/Runtime/Character/NetworkKCCTests.cs
+++ b/Packages/com.nickmaltbie.openkcc.netcode/Tests/Runtime/Character/NetworkKCCTests.cs
@@ -119,6 +119,13 @@ namespace nickmaltbie.openkcc.Tests.netcode.Runtime.Character
             e.GetComponent<CapsuleCollider>().enabled = objectIdx == clientIdx;
         }
 
+        /// <summary>
+        /// Validation basic transitions between idle state, walking state,
+        /// back to idle, then to jumping state for a networked KCC
+        /// and verify that these states are propagated to other clients
+        /// as well.
+        /// </summary>
+        /// <returns>Enumerator representing state of test.</returns>
         [UnityTest]
         public IEnumerator Validate_NetworkKCC_Move_Transition()
         {
@@ -143,6 +150,15 @@ namespace nickmaltbie.openkcc.Tests.netcode.Runtime.Character
             }
         }
 
+        /// <summary>
+        /// Spawn a set of players on a "MovingGroundConveyer" and verify
+        /// that the players move with the MovingGroundConveyer's baked
+        /// velocity.
+        /// 
+        /// Assert that when the players jump, they maintain some velocity
+        /// in the direction of the MovingGroundConveyer's motion as well.
+        /// </summary>
+        /// <returns>Enumerator representing state of test.</returns>
         [UnityTest]
         public IEnumerator Validate_NetworkKCC_MovingGround()
         {
@@ -180,6 +196,14 @@ namespace nickmaltbie.openkcc.Tests.netcode.Runtime.Character
                     }));
         }
 
+        /// <summary>
+        /// Create a set of players and verify that they transition
+        /// to sliding state on the owner as well as client
+        /// machines. Achieve this by rotating the floor and setting
+        /// the max walk angle for the players to be less than that of
+        /// the floor rotation.
+        /// </summary>
+        /// <returns>Enumerator representing state of test.</returns>
         [UnityTest]
         public IEnumerator Validate_NetworkKCC_Sliding()
         {
@@ -201,7 +225,7 @@ namespace nickmaltbie.openkcc.Tests.netcode.Runtime.Character
 
         protected IEnumerator SetupPlayersInIdleState()
         {
-            ForEachOwner((player, i) => player.TeleportPlayer(Vector3.right * i * 2 + Vector3.up * 0.1f));
+            ForEachOwner((player, i) => player.TeleportPlayer(Vector3.right * i * 2 + Vector3.up * 0.25f));
             SetupInputs();
             yield return TestUtils.WaitUntil(() => ForAllPlayers(player =>
             {


### PR DESCRIPTION
# Description

Fixing up some flaky conditions for playmode tests.

Specifically tests:
* NetworkKCCTests.Validate_NetworkKCC_Sliding
* NetworkKCCtests.Validate_NetworkKCC_MovingGround
* NetworkKCCtests.Validate_NetworkKCC_Sliding

The tests were getting stuck in the "LandingState" causing the players to never enter idle state. This was caused by this transition being driven by an animation. However, these animations were baked for the test and not using the real animations so it would only end if the frame of the play mode test happened to end before the animation reset. This was likely but not garneted so I added a backup transition that will force the state change after 1 second of landing. 

Additionally, I cleaned up some of the other extreme setting and added some documentation to the tests.
