### PR TITLE
Fixing Stuck on Corners

### DIFF
--- a/Packages/com.nickmaltbie.openkcc/CHANGELOG.md
+++ b/Packages/com.nickmaltbie.openkcc/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## In Progress
 
+* Removed reduction in momentum due to snapping up as it was causing player to
+    sometimes get stuck on corners of small slopes.
 * Updated project version to [2021.3.25f1](https://unity.com/releases/editor/whats-new/2021.3.25)
 * Corrected basic overlap for when feet intersect with a wall or ramp.
 * Added support for `LayerMask` for the `HumanoidFootIK` raycast checks

--- a/Packages/com.nickmaltbie.openkcc/OpenKCC/Animation/HumanoidFootIK.cs
+++ b/Packages/com.nickmaltbie.openkcc/OpenKCC/Animation/HumanoidFootIK.cs
@@ -346,7 +346,6 @@ namespace nickmaltbie.OpenKCC.Animation
         private void UpdateFootIKState(FootTarget target)
         {
             AvatarIKGoal goal = target.Foot == Foot.LeftFoot ? AvatarIKGoal.LeftFoot : AvatarIKGoal.RightFoot;
-            Vector3 targetPosition = target.TargetFootPosition;
             Transform hips = animator.GetBoneTransform(HumanBodyBones.Hips);
 
             // If we are overlapping with something, snap it back

--- a/Packages/com.nickmaltbie.openkcc/OpenKCC/Utils/KCCUtils.cs
+++ b/Packages/com.nickmaltbie.openkcc/OpenKCC/Utils/KCCUtils.cs
@@ -200,21 +200,7 @@ namespace nickmaltbie.OpenKCC.Utils
                 // Have the player move up up to the remaining momentum
                 float distanceMove = Mathf.Min(momentum.magnitude, distanceToSnap);
                 position += distanceMove * Vector3.up;
-
-                // Also move the player forward however far they can move
-                bool didForwardHit = config.ColliderCast.CastSelf(
-                    position,
-                    rotation,
-                    momentum.normalized,
-                    momentum.magnitude,
-                    out IRaycastHit forwardHit,
-                    config.LayerMask,
-                    queryTriggerInteraction: QueryTriggerInteraction.Ignore);
-
-                float forwardDist = didForwardHit ? Mathf.Max(0, forwardHit.distance - KCCUtils.Epsilon) : momentum.magnitude;
-                float remainingMomentum = Mathf.Max(0, momentum.magnitude - (distanceMove + forwardDist));
-                position += forwardDist * momentum.normalized;
-                momentum = momentum.normalized * remainingMomentum;
+                float remainingMomentum = Mathf.Max(0, momentum.magnitude - distanceMove);
                 return true;
             }
             // Otherwise move the player back down
@@ -391,7 +377,6 @@ namespace nickmaltbie.OpenKCC.Utils
 
             // Check if the player is running into a perpendicular surface
             bool perpendicularBounce = CheckPerpendicularBounce(hit, remainingMomentum, config);
-
             if (perpendicularBounce && AttemptSnapUp(hit, ref remainingMomentum, ref position, rotation, config))
             {
                 return new KCCBounce

--- a/Packages/com.nickmaltbie.openkcc/OpenKCC/Utils/KCCUtils.cs
+++ b/Packages/com.nickmaltbie.openkcc/OpenKCC/Utils/KCCUtils.cs
@@ -200,7 +200,6 @@ namespace nickmaltbie.OpenKCC.Utils
                 // Have the player move up up to the remaining momentum
                 float distanceMove = Mathf.Min(momentum.magnitude, distanceToSnap);
                 position += distanceMove * Vector3.up;
-                float remainingMomentum = Mathf.Max(0, momentum.magnitude - distanceMove);
                 return true;
             }
             // Otherwise move the player back down

--- a/Packages/com.nickmaltbie.openkcc/OpenKCC/Utils/KCCUtils.cs
+++ b/Packages/com.nickmaltbie.openkcc/OpenKCC/Utils/KCCUtils.cs
@@ -200,6 +200,7 @@ namespace nickmaltbie.OpenKCC.Utils
                 // Have the player move up up to the remaining momentum
                 float distanceMove = Mathf.Min(momentum.magnitude, distanceToSnap);
                 position += distanceMove * Vector3.up;
+                momentum /= 2;
                 return true;
             }
             // Otherwise move the player back down

--- a/Packages/com.nickmaltbie.openkcc/OpenKCC/Utils/KCCUtils.cs
+++ b/Packages/com.nickmaltbie.openkcc/OpenKCC/Utils/KCCUtils.cs
@@ -200,7 +200,6 @@ namespace nickmaltbie.OpenKCC.Utils
                 // Have the player move up up to the remaining momentum
                 float distanceMove = Mathf.Min(momentum.magnitude, distanceToSnap);
                 position += distanceMove * Vector3.up;
-                momentum /= 2;
                 return true;
             }
             // Otherwise move the player back down
@@ -377,14 +376,16 @@ namespace nickmaltbie.OpenKCC.Utils
 
             // Check if the player is running into a perpendicular surface
             bool perpendicularBounce = CheckPerpendicularBounce(hit, remainingMomentum, config);
-            if (perpendicularBounce && AttemptSnapUp(hit, ref remainingMomentum, ref position, rotation, config))
+            Vector3 snappedMomentum = remainingMomentum;
+            Vector3 snappedPosition = position;
+            if (perpendicularBounce && AttemptSnapUp(hit, ref snappedMomentum, ref snappedPosition, rotation, config))
             {
                 return new KCCBounce
                 {
                     initialPosition = initialPosition,
-                    finalPosition = position,
+                    finalPosition = snappedPosition,
                     initialMomentum = initialMomentum,
-                    remainingMomentum = remainingMomentum,
+                    remainingMomentum = snappedMomentum,
                     hit = hit,
                     action = MovementAction.SnapUp,
                 };

--- a/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Utils/KCCUtilsTests.cs
+++ b/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Utils/KCCUtilsTests.cs
@@ -221,9 +221,10 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode.Utils
             var bounces = GetBounces(Vector3.zero, Vector3.forward * 10, verticalSnapUp: snapUpDistance).ToList();
 
             // Validate bounce properties
-            Assert.IsTrue(bounces.Count == 2, $"Expected to find {3} bounce but instead found {bounces.Count}");
+            Assert.IsTrue(bounces.Count == 3, $"Expected to find {3} bounce but instead found {bounces.Count}");
             KCCValidation.ValidateKCCBounce(bounces[0], KCCUtils.MovementAction.SnapUp);
-            KCCValidation.ValidateKCCBounce(bounces[1], KCCUtils.MovementAction.Stop);
+            KCCValidation.ValidateKCCBounce(bounces[1], KCCUtils.MovementAction.Move);
+            KCCValidation.ValidateKCCBounce(bounces[2], KCCUtils.MovementAction.Stop);
         }
 
         /// <summary>


### PR DESCRIPTION
# Description

Fixing snapping up causing player getting stuck on corners. This was being caused by the player's snapping up removing too much of the momentum and sticking them in place.

Did this by breaking the move after snapping up into a separate action.

Also removed reduction in momentum due to snapping up... for now.
