### PR TITLE
Added Character Push via KCCMovementEngineWithPush

### DIFF
--- a/Assets/Samples/ExampleFirstPersonKCC/Character/Player.prefab
+++ b/Assets/Samples/ExampleFirstPersonKCC/Character/Player.prefab
@@ -44,11 +44,10 @@ GameObject:
   - component: {fileID: 1928389238801210309}
   - component: {fileID: 1928389238801210308}
   - component: {fileID: 1443923188}
-  - component: {fileID: 1014123492234295141}
   - component: {fileID: 6826506219202058344}
   - component: {fileID: 609951634059087576}
   - component: {fileID: 1928389240043740980}
-  - component: {fileID: 1755217166684006379}
+  - component: {fileID: 354279388133574573}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -112,10 +111,21 @@ Rigidbody:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1928389238801210305}
-  serializedVersion: 2
+  serializedVersion: 4
   m_Mass: 1
   m_Drag: 0
   m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
   m_UseGravity: 0
   m_IsKinematic: 0
   m_Interpolate: 0
@@ -129,8 +139,17 @@ CapsuleCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1928389238801210305}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
+  serializedVersion: 2
   m_Radius: 0.25
   m_Height: 1.65
   m_Direction: 1
@@ -147,19 +166,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: de2923ec207dbd24cbc85162a9a5130c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &1014123492234295141
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1928389238801210305}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fb8881fd8d6f824459325a88b4790336, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  pushPower: 4
 --- !u!114 &6826506219202058344
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -289,7 +295,7 @@ MonoBehaviour:
   walkingSpeed: 2.25
   sprintSpeed: 4
   jumpVelocity: 6.5
---- !u!114 &1755217166684006379
+--- !u!114 &354279388133574573
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -298,7 +304,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1928389238801210305}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 958f6019d666515419c7bf4b6a76110a, type: 3}
+  m_Script: {fileID: 11500000, guid: 4a56bd4d70332074d989b39cf2b69fc7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   serializationVersion: v1.0.0
@@ -306,12 +312,15 @@ MonoBehaviour:
   maxWalkAngle: 60
   layerMask:
     serializedVersion: 2
-    m_Bits: 2147483647
+    m_Bits: 4294967295
+  pushPower: 2
+  pushDecay: 0.8
 --- !u!1001 &1928389239579011581
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 1928389238801210310}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: f9a65e0222533fa4292d5c9cce96ca3c, type: 3}
@@ -371,6 +380,12 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: f9a65e0222533fa4292d5c9cce96ca3c, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1833340540}
   m_SourcePrefab: {fileID: 100100000, guid: f9a65e0222533fa4292d5c9cce96ca3c, type: 3}
 --- !u!1 &1585946679658927276 stripped
 GameObject:

--- a/Assets/Scripts/Debug/DebugFootIK.cs
+++ b/Assets/Scripts/Debug/DebugFootIK.cs
@@ -141,7 +141,6 @@ namespace nickmaltbie.OpenKCC.Animation
             _ = Vector3.zero;
             _ = Quaternion.identity;
             _ = Vector3.up;
-            GameObject floor = null;
             _ = transform.forward;
 
             foreach (Foot foot in Feet)
@@ -151,6 +150,7 @@ namespace nickmaltbie.OpenKCC.Animation
                 Quaternion rotation;
                 Vector3 groundNormal;
                 Vector3 footForward;
+                GameObject floor;
                 switch (debugType)
                 {
                     default:

--- a/Assets/Scripts/Debug/DebugFootIK.cs
+++ b/Assets/Scripts/Debug/DebugFootIK.cs
@@ -160,7 +160,7 @@ namespace nickmaltbie.OpenKCC.Animation
                     case DebugType.PlaceFeet:
                         if (target.State == FootState.Grounded)
                         {
-                            bool grounded = GetFootGroundedTransform(foot, out groundedPos, out rotation, out groundNormal, out floor, out footForward, false);
+                            bool grounded = GetFootGroundedTransform(foot, out groundedPos, out rotation, out groundNormal, out _, out _, false);
                             if (!grounded)
                             {
                                 target.ReleaseFoot();
@@ -183,7 +183,7 @@ namespace nickmaltbie.OpenKCC.Animation
                     case DebugType.LiftFeet:
                         if (target.State == FootState.Grounded)
                         {
-                            bool shouldRelease = target.UnderReleaseThreshold();
+                            _ = target.UnderReleaseThreshold();
                             bool grounded = GetFootTargetPosViaHips(foot, out groundedPos, out rotation, out groundNormal, out floor, out footForward, false);
                             if (!grounded)
                             {

--- a/Documentation/manual/kcc-design/make-your-own-kcc.md
+++ b/Documentation/manual/kcc-design/make-your-own-kcc.md
@@ -78,6 +78,16 @@ and allows for the mole to be considered
 "grounded" no matter what angle they
 are standing at.
 
+A good example of this level of customization is overriding the bounces and
+[KCCMovementEngine.GetMovement](xref:nickmaltbie.OpenKCC.Character.KCCMovementEngine.GetMovement(Vector3))
+similar to the [KCCMovementEngineWithPush](xref:nickmaltbie.OpenKCC.Character.KCCMovementEngineWithPush)
+which overrides the `GetMovement` function to inject push events on
+rigidbody objects that the player collides with.
+
+Or even the [MoleMovementEngine](xref:nickmaltbie.OpenKCC.MoleKCCSample.MoleMovementEngine)
+for an example of changing it enough to allow for different kinds of navigation
+in the world.
+
 ## Low Level Customization
 
 If you want to be entirely custom in the character

--- a/Packages/com.nickmaltbie.openkcc/CHANGELOG.md
+++ b/Packages/com.nickmaltbie.openkcc/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## In Progress
 
+* Re-implemented example `KCCMovementEngineWithPush` to show how to use
+    `ICharacterPush` to push objects with the `KCCMovementEngine`
+
 ## [1.4.0] 2024-06-12
 
 * Removed `Moq` dependency for tests.

--- a/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/KCCMovementEngine.cs
+++ b/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/KCCMovementEngine.cs
@@ -48,7 +48,7 @@ namespace nickmaltbie.OpenKCC.Character
         /// <summary>
         /// Default maximum number of bounces for computing player movement.
         /// </summary>
-        public const float DefaultMaxBounces = 5f;
+        public const int DefaultMaxBounces = 5;
 
         /// <summary>
         /// Default expected depth of a step for walking up staircases.
@@ -73,7 +73,7 @@ namespace nickmaltbie.OpenKCC.Character
         /// <summary>
         /// Max launch speed of player form moving ground.
         /// </summary>
-        public const float DefaultMaxLaunchVelocity = 5.0f;
+        public const float DefaultMaxLaunchVelocity = 2.0f;
 
         /// <summary>
         /// Serialization version for the KCCMovementEngine.
@@ -110,12 +110,12 @@ namespace nickmaltbie.OpenKCC.Character
         /// <summary>
         /// Distance to ground at which player is considered grounded.
         /// </summary>
-        public virtual float GroundedDistance => 0.05f;
+        public virtual float GroundedDistance => DefaultGroundedDistance;
 
         /// <summary>
         /// Distance to check player distance to ground.
         /// </summary>
-        public virtual float GroundCheckDistance => 0.25f;
+        public virtual float GroundCheckDistance => DefaultGroundCheckDistance;
 
         /// <summary>
         /// Maximum angle at which the player can walk (in degrees).
@@ -123,22 +123,22 @@ namespace nickmaltbie.OpenKCC.Character
         public virtual float MaxWalkAngle => maxWalkAngle;
 
         /// <inheritdoc/>
-        public virtual int MaxBounces => 5;
+        public virtual int MaxBounces => DefaultMaxBounces;
 
         /// <inheritdoc/>
         public virtual float VerticalSnapUp => stepHeight;
 
         /// <inheritdoc/>
-        public virtual float StepUpDepth => 0.1f;
+        public virtual float StepUpDepth => DefaultStepUpDepth;
 
         /// <inheritdoc/>
-        public virtual float AnglePower => 2.0f;
+        public virtual float AnglePower => DefaultAnglePower;
 
         /// <summary>
         /// Max push speed of the player in units per second when pushing
         /// out of overlapping objects.
         /// </summary>
-        public float MaxPushSpeed => 100.0f;
+        public float MaxPushSpeed => DefaultMaxPushSpeed;
 
         /// <summary>
         /// Layermask for computing player collisions.
@@ -163,7 +163,7 @@ namespace nickmaltbie.OpenKCC.Character
         /// Max default launch velocity for the player from unlabeled
         /// surfaces.
         /// </summary>
-        public virtual float MaxDefaultLaunchVelocity => 5.0f;
+        public virtual float MaxDefaultLaunchVelocity => DefaultMaxLaunchVelocity;
 
         /// <summary>
         /// Maximum speed at which the player can snap down surfaces.

--- a/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/KCCMovementEngineWithPush.cs
+++ b/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/KCCMovementEngineWithPush.cs
@@ -23,18 +23,28 @@ using UnityEngine;
 
 namespace nickmaltbie.OpenKCC.Character
 {
+    /// <summary>
+    /// Basic extension of KCCMovementEngine that allows for
+    /// pushing rigidbody objects that it collides with that
+    /// have the attached MonoBehaviour IPushable.
+    /// </summary>
     [RequireComponent(typeof(Rigidbody))]
     [RequireComponent(typeof(IColliderCast))]
     public class KCCMovementEngineWithPush : KCCMovementEngine, ICharacterPush
     {
         /// <summary>
-        /// Power of the player push
+        /// Power of the player push.
         /// </summary>
-        public float pushPower = 2.0f;
+        [Tooltip("Power of the player push.")]
+        public float pushPower = 4.0f;
 
         /// <summary>
-        /// Decrease in momentum when pushing an object.
+        /// Decay in momentum when pushing an object.
+        /// Zero indicates all momentum is lost while 1 indicates all momentum
+        /// is maintained.
         /// </summary>
+        [Range(0, 1)]
+        [Tooltip("Decay in momentum when pushing an object.")]
         public float pushDecay = 0.8f;
 
         /// <inheritdoc/>

--- a/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/KCCMovementEngineWithPush.cs
+++ b/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/KCCMovementEngineWithPush.cs
@@ -16,22 +16,26 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.Collections.Generic;
 using nickmaltbie.OpenKCC.Environment.Pushable;
 using nickmaltbie.OpenKCC.Utils;
-
 using UnityEngine;
 
 namespace nickmaltbie.OpenKCC.Character
 {
-    /// <summary>
-    /// Have a character controller push any dynamic rigidbody it hits
-    /// </summary>
-    public class CharacterPush : MonoBehaviour, ICharacterPush
+    [RequireComponent(typeof(Rigidbody))]
+    [RequireComponent(typeof(IColliderCast))]
+    public class KCCMovementEngineWithPush : KCCMovementEngine, ICharacterPush
     {
         /// <summary>
         /// Power of the player push
         /// </summary>
         public float pushPower = 2.0f;
+
+        /// <summary>
+        /// Decrease in momentum when pushing an object.
+        /// </summary>
+        public float pushDecay = 0.8f;
 
         /// <inheritdoc/>
         public bool CanPushObject(Collider hit)
@@ -67,6 +71,33 @@ namespace nickmaltbie.OpenKCC.Character
                 pushForce,
                 hit.point,
                 (int)ForceMode.Force);
+        }
+
+        /// <inheritdoc/>
+        public override IEnumerable<KCCBounce> GetMovement(Vector3 movement)
+        {
+            foreach (KCCBounce bounce in base.GetMovement(movement))
+            {
+                if (bounce.action == KCCUtils.MovementAction.Bounce && CanPushObject(bounce.hit?.collider))
+                {
+                    Collider collider = bounce.hit.collider;
+                    PushObject(new KinematicCharacterControllerHit(
+                        collider,
+                        bounce.hit.rigidbody,
+                        collider.gameObject,
+                        collider.transform,
+                        bounce.hit.point,
+                        bounce.hit.normal,
+                        bounce.initialMomentum.normalized,
+                        movement.magnitude
+                    ));
+
+                    // If pushing something, reduce remaining force significantly
+                    bounce.remainingMomentum *= pushDecay;
+                }
+
+                yield return bounce;
+            }
         }
     }
 }

--- a/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/KCCMovementEngineWithPush.cs.meta
+++ b/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/KCCMovementEngineWithPush.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: fb8881fd8d6f824459325a88b4790336
+guid: 4a56bd4d70332074d989b39cf2b69fc7
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Character/CharacterPushTests.cs
+++ b/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Character/CharacterPushTests.cs
@@ -28,7 +28,7 @@ using UnityEngine;
 namespace nickmaltbie.OpenKCC.Tests.EditMode.Character
 {
     /// <summary>
-    /// Basic tests for <see cref="nickmaltbie.OpenKCC.Character.CharacterPush"/> in edit mode.
+    /// Basic tests for <see cref="nickmaltbie.OpenKCC.Character.KCCMovementEngineWithPush"/> in edit mode.
     /// </summary>
     [TestFixture]
     public class CharacterPushTests : TestBase

--- a/Packages/com.nickmaltbie.openkcc/Tests/PlayMode/Utils/KCCUtilsScenarioTests.cs
+++ b/Packages/com.nickmaltbie.openkcc/Tests/PlayMode/Utils/KCCUtilsScenarioTests.cs
@@ -83,7 +83,6 @@ namespace nickmaltbie.OpenKCC.Tests.PlayMode.Utils
             collider.height = 2.0f;
 
             playerColliderCast = character.AddComponent<CapsuleColliderCast>();
-            characterPush = character.AddComponent<CharacterPush>();
 
             Mesh capsuleMesh = CapsuleMaker.CapsuleData(depth: 1.0f);
             capsuleMesh.vertices = capsuleMesh.vertices.Select(vert => vert + Vector3.up).ToArray();


### PR DESCRIPTION
# Description

Added new class `KCCMovementEngineWithPush` which allows for pushing game objects with the `IPushable` attached MonoBehaviour.

Closes #212 

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have documentation my code, particularly in hard-to-understand areas
- [x] I have added tests that demonstrate the new feature or bugfix

