### PR TITLE
Overlap Tests

### DIFF
--- a/Assets/Samples/NetcodeExample/Common/Scripts/NetworkControls.cs
+++ b/Assets/Samples/NetcodeExample/Common/Scripts/NetworkControls.cs
@@ -19,7 +19,6 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
-using System.Text;
 using System.Threading;
 using nickmaltbie.ScreenManager;
 using TMPro;

--- a/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Character/Config/KCCGroundedStateTests.cs
+++ b/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Character/Config/KCCGroundedStateTests.cs
@@ -104,5 +104,19 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode.Character.Config
             Assert.IsTrue(kccGroundedState.Sliding);
             Assert.IsTrue(kccGroundedState.DistanceToGround == 0.001f);
         }
+
+        [Test]
+        public void Validate_KCCGroundedState_SkinWidth()
+        {
+            KCCTestUtils.SetupCastSelf(colliderCastMock, normal: Vector3.up, distance: 0, didHit: true);
+            movementEngine.skinWidth = 0.1f;
+            kccGroundedState = movementEngine.CheckGrounded(false, false);
+
+            TestUtils.AssertInBounds(kccGroundedState.Angle, 0.0f);
+            Assert.IsTrue(kccGroundedState.StandingOnGround);
+            Assert.IsTrue(kccGroundedState.StandingOnGroundOrOverlap);
+            Assert.IsTrue(kccGroundedState.DistanceToGround == 0);
+            Assert.IsFalse(kccGroundedState.Sliding);
+        }
     }
 }

--- a/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Character/KCCStateMachineTests.cs
+++ b/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Character/KCCStateMachineTests.cs
@@ -63,7 +63,6 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode.Character
         {
             base.TearDown();
             PlayerInputUtils.playerMovementState = PlayerInputState.Allow;
-
         }
 
         [Test]

--- a/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Utils/ColliderCast/BoxColliderCastTests.cs
+++ b/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Utils/ColliderCast/BoxColliderCastTests.cs
@@ -114,6 +114,20 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode.Utils.ColliderCast
         }
 
         [Test]
+        public void Validate_GetOverlapSkinWidth()
+        {
+            MakeCube();
+            Assert.IsNotEmpty(boxCast.GetOverlapping(Vector3.forward, Quaternion.identity, skinWidth: 0));
+            Assert.IsEmpty(boxCast.GetOverlapping(Vector3.forward, Quaternion.identity, skinWidth: 0.1f));
+            Assert.IsEmpty(boxCast.GetOverlapping(Vector3.forward, Quaternion.identity, skinWidth: 0.2f));
+            Assert.IsEmpty(boxCast.GetOverlapping(Vector3.forward, Quaternion.identity, skinWidth: 0.3f));
+            Assert.IsEmpty(boxCast.GetOverlapping(Vector3.forward, Quaternion.identity, skinWidth: 0.4f));
+            Assert.IsEmpty(boxCast.GetOverlapping(Vector3.forward, Quaternion.identity, skinWidth: 0.5f));
+            Assert.IsNotEmpty(boxCast.GetOverlapping(Vector3.forward * 0.5f, Quaternion.identity, skinWidth: 0.1f));
+            Assert.IsEmpty(boxCast.GetOverlapping(Vector3.forward * 1.5f, Quaternion.identity, skinWidth: 0.1f));
+        }
+
+        [Test]
         public void Validate_GetOverlapping([NUnit.Framework.Range(1, 10, 2)] int numOverlap)
         {
             GameObject[] targets = Enumerable.Range(0, numOverlap).Select(_ => MakeCube()).ToArray();

--- a/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Utils/ColliderCast/BoxColliderCastTests.cs
+++ b/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Utils/ColliderCast/BoxColliderCastTests.cs
@@ -23,6 +23,7 @@ using nickmaltbie.OpenKCC.Utils.ColliderCast;
 using nickmaltbie.TestUtilsUnity.Tests.TestCommon;
 using NUnit.Framework;
 using UnityEngine;
+using static nickmaltbie.OpenKCC.Utils.KCCUtils;
 
 namespace nickmaltbie.OpenKCC.Tests.EditMode.Utils.ColliderCast
 {
@@ -111,6 +112,20 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode.Utils.ColliderCast
             GameObject target = MakeCube(Vector3.forward * dist);
             Assert.IsTrue(boxCast.CastSelf(Vector3.zero, Quaternion.identity, Vector3.forward, dist + 1, out IRaycastHit hit));
             Assert.IsTrue(hit.rigidbody.gameObject == target);
+        }
+
+        [Test]
+        public void Validate_NoBounceWithZeroDistance()
+        {
+            MakeCube();
+            var config = new KCCConfig
+            {
+                ColliderCast = boxCast,
+                SkinWidth = 0.1f,
+            };
+            KCCBounce bounce = KCCUtils.SingleKCCBounce(Vector3.up, Vector3.forward, Vector3.forward, Quaternion.identity, config);
+            Assert.AreEqual(MovementAction.Move, bounce.action);
+            Assert.AreEqual(bounce.finalPosition - bounce.initialPosition, Vector3.forward);
         }
 
         [Test]

--- a/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Utils/ColliderCast/CapsuleColliderCastTests.cs
+++ b/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Utils/ColliderCast/CapsuleColliderCastTests.cs
@@ -183,6 +183,20 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode.Utils.ColliderCast
         }
 
         [Test]
+        public void Validate_GetOverlapSkinWidth()
+        {
+            MakeCube();
+            Assert.IsNotEmpty(colliderCast.GetOverlapping(Vector3.forward, Quaternion.identity, skinWidth: 0));
+            Assert.IsEmpty(colliderCast.GetOverlapping(Vector3.forward, Quaternion.identity, skinWidth: 0.1f));
+            Assert.IsEmpty(colliderCast.GetOverlapping(Vector3.forward, Quaternion.identity, skinWidth: 0.2f));
+            Assert.IsEmpty(colliderCast.GetOverlapping(Vector3.forward, Quaternion.identity, skinWidth: 0.3f));
+            Assert.IsEmpty(colliderCast.GetOverlapping(Vector3.forward, Quaternion.identity, skinWidth: 0.4f));
+            Assert.IsEmpty(colliderCast.GetOverlapping(Vector3.forward, Quaternion.identity, skinWidth: 0.5f));
+            Assert.IsNotEmpty(colliderCast.GetOverlapping(Vector3.forward * 0.5f, Quaternion.identity, skinWidth: 0.1f));
+            Assert.IsEmpty(colliderCast.GetOverlapping(Vector3.forward * 1.5f, Quaternion.identity, skinWidth: 0.1f));
+        }
+
+        [Test]
         public void Validate_DebugCapsuleMesh()
         {
             Assert.AreEqual(colliderCast.DebugCapsuleMesh, colliderCast.DebugCapsuleMesh);

--- a/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Utils/ColliderCast/CapsuleColliderCastTests.cs
+++ b/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Utils/ColliderCast/CapsuleColliderCastTests.cs
@@ -23,6 +23,7 @@ using nickmaltbie.OpenKCC.Utils.ColliderCast;
 using nickmaltbie.TestUtilsUnity.Tests.TestCommon;
 using NUnit.Framework;
 using UnityEngine;
+using static nickmaltbie.OpenKCC.Utils.KCCUtils;
 
 namespace nickmaltbie.OpenKCC.Tests.EditMode.Utils.ColliderCast
 {
@@ -180,6 +181,20 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode.Utils.ColliderCast
             GameObject target = MakeCube(Vector3.forward * 1);
             Assert.IsTrue(colliderCast.CastSelf(Vector3.zero, Quaternion.identity, Vector3.forward, 5, out IRaycastHit hit));
             Assert.IsTrue(hit.rigidbody.gameObject == target);
+        }
+
+        [Test]
+        public void Validate_NoBounceWithZeroDistance()
+        {
+            MakeCube();
+            var config = new KCCConfig
+            {
+                ColliderCast = colliderCast,
+                SkinWidth = 0.1f,
+            };
+            KCCBounce bounce = KCCUtils.SingleKCCBounce(Vector3.up * 1.5f, Vector3.forward, Vector3.forward, Quaternion.identity, config);
+            Assert.AreEqual(MovementAction.Move, bounce.action);
+            Assert.AreEqual(bounce.finalPosition - bounce.initialPosition, Vector3.forward);
         }
 
         [Test]

--- a/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Utils/ColliderCast/SphereColliderCastTests.cs
+++ b/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Utils/ColliderCast/SphereColliderCastTests.cs
@@ -23,6 +23,7 @@ using nickmaltbie.OpenKCC.Utils.ColliderCast;
 using nickmaltbie.TestUtilsUnity.Tests.TestCommon;
 using NUnit.Framework;
 using UnityEngine;
+using static nickmaltbie.OpenKCC.Utils.KCCUtils;
 
 namespace nickmaltbie.OpenKCC.Tests.EditMode.Utils.ColliderCast
 {
@@ -159,6 +160,20 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode.Utils.ColliderCast
             GameObject target = MakeCube(Vector3.forward * 1);
             Assert.IsTrue(sphereCast.CastSelf(Vector3.zero, Quaternion.identity, Vector3.forward, 5, out IRaycastHit hit));
             Assert.IsTrue(hit.rigidbody.gameObject == target);
+        }
+
+        [Test]
+        public void Validate_NoBounceWithZeroDistance()
+        {
+            MakeCube();
+            var config = new KCCConfig
+            {
+                ColliderCast = sphereCast,
+                SkinWidth = 0.1f,
+            };
+            KCCBounce bounce = KCCUtils.SingleKCCBounce(Vector3.up, Vector3.forward, Vector3.forward, Quaternion.identity, config);
+            Assert.AreEqual(MovementAction.Move, bounce.action);
+            Assert.AreEqual(bounce.finalPosition - bounce.initialPosition, Vector3.forward);
         }
 
         [Test]

--- a/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Utils/ColliderCast/SphereColliderCastTests.cs
+++ b/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Utils/ColliderCast/SphereColliderCastTests.cs
@@ -161,6 +161,20 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode.Utils.ColliderCast
             Assert.IsTrue(hit.rigidbody.gameObject == target);
         }
 
+        [Test]
+        public void Validate_GetOverlapSkinWidth()
+        {
+            MakeCube();
+            Assert.IsNotEmpty(sphereCast.GetOverlapping(Vector3.forward, Quaternion.identity, skinWidth: 0));
+            Assert.IsEmpty(sphereCast.GetOverlapping(Vector3.forward, Quaternion.identity, skinWidth: 0.1f));
+            Assert.IsEmpty(sphereCast.GetOverlapping(Vector3.forward, Quaternion.identity, skinWidth: 0.2f));
+            Assert.IsEmpty(sphereCast.GetOverlapping(Vector3.forward, Quaternion.identity, skinWidth: 0.3f));
+            Assert.IsEmpty(sphereCast.GetOverlapping(Vector3.forward, Quaternion.identity, skinWidth: 0.4f));
+            Assert.IsEmpty(sphereCast.GetOverlapping(Vector3.forward, Quaternion.identity, skinWidth: 0.5f));
+            Assert.IsNotEmpty(sphereCast.GetOverlapping(Vector3.forward * 0.5f, Quaternion.identity, skinWidth: 0.1f));
+            Assert.IsEmpty(sphereCast.GetOverlapping(Vector3.forward * 1.5f, Quaternion.identity, skinWidth: 0.1f));
+        }
+
         private GameObject MakeCube(Vector3? position = null)
         {
             var target = GameObject.CreatePrimitive(PrimitiveType.Cube);

--- a/Packages/com.nickmaltbie.openkcc/Tests/PlayMode/Character/KCCStateMachineMovementTests.cs
+++ b/Packages/com.nickmaltbie.openkcc/Tests/PlayMode/Character/KCCStateMachineMovementTests.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (C) 2023 Nicholas Maltbie
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections;
+using nickmaltbie.OpenKCC.Tests.TestCommon;
+using nickmaltbie.TestUtilsUnity.Tests.TestCommon;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace nickmaltbie.OpenKCC.Tests.PlayMode.Character
+{
+    public class KCCStateMachineMovementTests : KCCStateMachineTestBase
+    {
+        private GameObject floor;
+
+        [SetUp]
+        public override void Setup()
+        {
+            base.Setup();
+            floor = new GameObject();
+            BoxCollider box = floor.AddComponent<BoxCollider>();
+            box.center = new Vector3(0, -0.5f, 0);
+            box.size = new Vector3(10, 1, 10);
+            box.transform.position = Vector3.zero;
+            box.transform.rotation = Quaternion.identity;
+            kccStateMachine.transform.position = Vector3.zero;
+        }
+
+        [TearDown]
+        public override void TearDown()
+        {
+            base.TearDown();
+            Object.DestroyImmediate(floor);
+        }
+
+        [UnityTest]
+        public IEnumerator Validate_KCCStateMachine_NoMovement()
+        {
+            Vector3 initialPosition = kccStateMachine.transform.position;
+
+            // Wait for a second, ensure no player movement ocurrs
+            for (int i = 0; i < 60; i++)
+            {
+                yield return new WaitForFixedUpdate();
+            }
+
+            Assert.AreEqual(initialPosition, kccStateMachine.transform.position);
+        }
+
+        [UnityTest]
+        public IEnumerator Validate_KCCStateMachine_BasicMovement()
+        {
+            Vector3 initialPosition = kccStateMachine.transform.position;
+            kccStateMachine.walkingSpeed = 1.0f;
+            kccStateMachine.Update();
+            Set(moveStick, Vector2.up);
+
+            // Wait for a second, ensure no player movement ocurrs
+            for (int i = 0; i < 60; i++)
+            {
+                yield return new WaitForFixedUpdate();
+            }
+
+            TestUtils.AssertInBounds(
+                initialPosition + Vector3.forward * kccStateMachine.walkingSpeed,
+                kccStateMachine.transform.position, 0.25f);
+        }
+    }
+}

--- a/Packages/com.nickmaltbie.openkcc/Tests/PlayMode/Character/KCCStateMachineMovementTests.cs.meta
+++ b/Packages/com.nickmaltbie.openkcc/Tests/PlayMode/Character/KCCStateMachineMovementTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8792f1b5df3dafc46b8ac5e8e501f975
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.nickmaltbie.openkcc/Tests/PlayMode/Character/KCCStateMachineMovingGroundTests.cs
+++ b/Packages/com.nickmaltbie.openkcc/Tests/PlayMode/Character/KCCStateMachineMovingGroundTests.cs
@@ -56,13 +56,20 @@ namespace nickmaltbie.OpenKCC.Tests.PlayMode.Character
         public override void Setup()
         {
             base.Setup();
-            floor = CreateGameObject();
+            floor = new GameObject();
             BoxCollider box = floor.AddComponent<BoxCollider>();
             box.center = Vector3.zero;
             box.size = new Vector3(10, 1, 10);
             box.transform.position = Vector3.zero;
             box.transform.rotation = Quaternion.identity;
             floor.transform.position = new Vector3(0, -0.5f, 0);
+        }
+
+        [TearDown]
+        public override void TearDown()
+        {
+            base.TearDown();
+            GameObject.DestroyImmediate(floor);
         }
 
         [UnityTest]

--- a/Packages/com.nickmaltbie.openkcc/Tests/TestCommon/KCCStateMachineTestBase.cs
+++ b/Packages/com.nickmaltbie.openkcc/Tests/TestCommon/KCCStateMachineTestBase.cs
@@ -16,6 +16,7 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.Collections.Generic;
 using nickmaltbie.OpenKCC.Character;
 using nickmaltbie.OpenKCC.Character.Action;
 using nickmaltbie.OpenKCC.Character.Animation;
@@ -39,6 +40,8 @@ namespace nickmaltbie.OpenKCC.Tests.TestCommon
     /// </summary>
     public class KCCStateMachineTestBase : TestBase
     {
+        protected InputActionAsset inputActionAsset;
+
         protected StickControl moveStick;
         protected ButtonControl jumpButton;
         protected ButtonControl sprintButton;
@@ -57,7 +60,7 @@ namespace nickmaltbie.OpenKCC.Tests.TestCommon
         {
             base.Setup();
 
-            GameObject go = CreateGameObject();
+            var go = new GameObject();
             CapsuleCollider capsuleCollider = go.AddComponent<CapsuleCollider>();
             go.AddComponent<CapsuleColliderCast>();
             capsuleCollider.center = new Vector3(0, 1, 0);
@@ -83,12 +86,9 @@ namespace nickmaltbie.OpenKCC.Tests.TestCommon
             anim.runtimeAnimatorController = controller;
 
             var jumpInput = new BufferedInput();
-            PlayerInput playerInput = go.AddComponent<PlayerInput>();
             gamepad = InputSystem.AddDevice<Gamepad>();
-            InputActionAsset inputActionAsset = CreateScriptableObject<InputActionAsset>();
+            inputActionAsset = ScriptableObject.CreateInstance<InputActionAsset>();
             InputActionMap actionMap = inputActionAsset.AddActionMap("testMap");
-            playerInput.actions = inputActionAsset;
-            playerInput.currentActionMap = actionMap;
             jumpButton = gamepad.aButton;
             sprintButton = gamepad.bButton;
             moveStick = gamepad.leftStick;
@@ -119,7 +119,8 @@ namespace nickmaltbie.OpenKCC.Tests.TestCommon
         public override void TearDown()
         {
             InputSystem.RemoveDevice(gamepad);
-            GameObject.DestroyImmediate(kccStateMachine.gameObject);
+            Object.DestroyImmediate(kccStateMachine.gameObject);
+            ScriptableObject.DestroyImmediate(inputActionAsset);
             base.TearDown();
         }
     }

--- a/Packages/com.nickmaltbie.openkcc/Tests/TestCommon/KCCStateMachineTestBase.cs
+++ b/Packages/com.nickmaltbie.openkcc/Tests/TestCommon/KCCStateMachineTestBase.cs
@@ -16,7 +16,6 @@
 // ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections.Generic;
 using nickmaltbie.OpenKCC.Character;
 using nickmaltbie.OpenKCC.Character.Action;
 using nickmaltbie.OpenKCC.Character.Animation;


### PR DESCRIPTION
# Description

Added Overlap Tests for the KCCStateMachine to ensure skin width works as expected and player does not drift when not moving.