### PR TITLE
Character Jumping Bugfix

### DIFF
--- a/Packages/com.nickmaltbie.openkcc/CHANGELOG.md
+++ b/Packages/com.nickmaltbie.openkcc/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## In Progress
 
+* Fixed small bug in `KCCStateMachine` causing player to stop jumping
+    when they are walking up steps or slopes.
 * Added `SkinWidth` parameter to `IKCCConfig` and `KCCMovementEngine` to allow
     for a buffer space around the character when computing movement to avoid
     numerical precision errors for physics system.

--- a/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/KCCStateMachine.cs
+++ b/Packages/com.nickmaltbie.openkcc/OpenKCC/Character/KCCStateMachine.cs
@@ -313,7 +313,7 @@ namespace nickmaltbie.OpenKCC.Character
             {
                 Velocity += Physics.gravity * unityService.fixedDeltaTime;
             }
-            else if (movementEngine.GroundedState.StandingOnGround)
+            else if (movementEngine.GroundedState.StandingOnGround && !movementEngine.MovingUp(Velocity))
             {
                 Velocity = Vector3.zero;
             }

--- a/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Character/KCCStateMachineTests.cs
+++ b/Packages/com.nickmaltbie.openkcc/Tests/EditMode/Character/KCCStateMachineTests.cs
@@ -46,7 +46,7 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode.Character
             base.Setup();
 
             unityServiceMock = new MockUnityService();
-            colliderCastMock = new MockColliderCast();
+            colliderCastMock = kccStateMachine.gameObject.AddComponent<MockColliderCast>();
             cameraControlsMock = new MockCameraControls();
 
             unityServiceMock.deltaTime = 1.0f;
@@ -184,6 +184,23 @@ namespace nickmaltbie.OpenKCC.Tests.EditMode.Character
             Assert.IsTrue(KCCGroundedState.StandingOnGround);
             Assert.IsFalse(KCCGroundedState.Sliding);
             Assert.IsFalse(KCCGroundedState.Falling);
+        }
+
+        [Test]
+        public void Validate_KCCStateMachine_DontCancelVelocityWhenMovingUp()
+        {
+            KCCTestUtils.SetupCastSelf(colliderCastMock, distance: 0.001f, normal: Vector3.up, didHit: true);
+            kccStateMachine.Update();
+
+            // Set the character's velocity to some upward value
+            kccStateMachine.ApplyJump(Vector3.up * 5);
+
+            // Assert that the velocity is not zeroed out despite the player being
+            // grounded at the current time.
+            kccStateMachine.FixedUpdate();
+
+            Assert.IsTrue(KCCGroundedState.StandingOnGround);
+            Assert.AreNotEqual(Vector3.zero, kccStateMachine.Velocity);
         }
 
         [Test]


### PR DESCRIPTION
# Description

Identified source of bug causing player to stop when jumping up steps. Turns out the player was considered 'grounded' while jumping and cancelled momentum. So, I needed to stop this and only zero out the player momentum if they are not moving up. 

Setup test and behavior to prevent player from losing momentum when jumping jump steps.

Closes #218 
